### PR TITLE
Logging to help gather more information on JukeAlert Issue#5

### DIFF
--- a/src/com/untamedears/citadel/GroupManager.java
+++ b/src/com/untamedears/citadel/GroupManager.java
@@ -129,7 +129,11 @@ public class GroupManager {
                 for (FactionMember fm : dbMembers) {
                     try {
                         members.add(UUID.fromString(fm.getMemberName()));
-                    } catch (Exception ex) {}
+                    } catch (Exception ex) {
+                    	String warningMessage = "Exception in GroupManager.java could not get information on group name " + 
+                    		(groupName==null ? "null" : groupName) + ".  " + ex.toString();
+                    	Citadel.warning(warningMessage);
+                    }
                 }
                 this.memberStorage.put(normalizedGroupName, members);
             }

--- a/src/com/untamedears/citadel/entity/FactionMember.java
+++ b/src/com/untamedears/citadel/entity/FactionMember.java
@@ -31,6 +31,13 @@ public class FactionMember implements Comparable {
 	public FactionMember(String memberName, String factionName){
 		this.memberName = memberName;
 		this.factionName = factionName;
+		
+		if (memberName == null){
+			Citadel.info("FactionMember.Java - Faction Member created without member name.  For faction name " + ((factionName==null)?"null":factionName));
+		}
+		if (factionName == null){
+			Citadel.info("FactionMember.Java - Faction Member created without faction name.  For member name " + ((memberName==null)?"null":memberName));
+		}
 	}
 
 	public String getMemberName(){
@@ -47,7 +54,21 @@ public class FactionMember implements Comparable {
     }
 
     public Player getPlayer() {
-        return Bukkit.getPlayer(UUID.fromString(memberName));
+    	Player thePlayer;
+    	
+    	try {
+    		thePlayer = Bukkit.getPlayer(UUID.fromString(memberName));
+    	} catch (Exception ex) {
+    		thePlayer = null;
+    		
+    		String errorMessage = "Exception in FactionMember.java for member name " + (memberName == null ? "null" : memberName) +
+    				" that is part of faction " + (factionName == null ? "null" : factionName) +
+    				ex.toString()
+    				;
+    		Citadel.warning(errorMessage);
+    	}
+    	
+        return thePlayer; 
     }
 
 	public String getFactionName(){


### PR DESCRIPTION
Added logging when faction members are created without the appropriate
data and in the specific case where we are getting errors now.  These
will show info / warning messages where appropriate.  Hopefully this
will expose additional information that may help debug this issue.

NOTE: The juke alert issue really does seem to belong to citadel
instead, suggest closing said issue and reopening in citadel perhaps.
