### PR TITLE
Added a check to canPlace for if the block is reinforced

### DIFF
--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -375,6 +375,15 @@ public class BlockListener implements Listener{
                 }
             }
         }
+        //stops players from modifying the reinforcement on a half slab by placing another block on top
+        Reinforcement reinforcement_on_block = Citadel.getReinforcementManager().getReinforcement(block);
+        if (reinforcement_on_block instanceof PlayerReinforcement) {
+            PlayerReinforcement reinforcement = (PlayerReinforcement) reinforcement_on_block;
+            if (!reinforcement.isBypassable(player))
+                return false;
+        } else if (reinforcement_on_block != null)
+            return false; //not really sure when this could happen but just in case
+
         return true;
     }
 	


### PR DESCRIPTION
As mentioned in the issue I raised I was unable to disallow my own access to a group I created so I couldn't fully check this. It did, however still let me place and reinforce blocks as normal.

The only questionable part is that I default to not allowing the user to place a block if getReinforcement() ever returns something other than a PlayerReinforcement (that isn't null).