### PR TITLE
Adds tab completion to Citadel commands

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: Citadel
 main: vg.civcraft.mc.citadel.Citadel
-version: 3.1.8
+version: 3.1.9
 author: Rourke750
 depend: [NameLayer]
 commands:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.citadel</groupId>
   <artifactId>Citadel</artifactId>
   <packaging>jar</packaging>
-  <version>3.1.8-${build.number}</version>
+  <version>3.1.9-${build.number}</version>
   <name>Citadel</name>
   <url>https://github.com/Civcraft/Citadel</url>
   

--- a/src/vg/civcraft/mc/citadel/Citadel.java
+++ b/src/vg/civcraft/mc/citadel/Citadel.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.citadel;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -116,5 +117,9 @@ public class Citadel extends JavaPlugin{
 	
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 		return cHandle.execute(sender, cmd, args);
+	}
+
+	public List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args){
+		return cHandle.complete(sender, cmd, args);
 	}
 }

--- a/src/vg/civcraft/mc/citadel/command/Command.java
+++ b/src/vg/civcraft/mc/citadel/command/Command.java
@@ -1,6 +1,9 @@
 package vg.civcraft.mc.citadel.command;
 
 import org.bukkit.command.CommandSender;
+
+import java.util.List;
+
 /**
  * 
  * The Interface class for all commands.
@@ -8,6 +11,7 @@ import org.bukkit.command.CommandSender;
  */
 public interface Command {
 	public boolean execute(CommandSender sender, String[] args);
+	public List<String> tabComplete	(CommandSender 	sender, String[] args);
 	public String getName();
 	public String getDescription();
 	public String getUsage();

--- a/src/vg/civcraft/mc/citadel/command/CommandHandler.java
+++ b/src/vg/civcraft/mc/citadel/command/CommandHandler.java
@@ -1,6 +1,7 @@
 package vg.civcraft.mc.citadel.command;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.bukkit.ChatColor;
@@ -54,6 +55,23 @@ public class CommandHandler {
 			command.execute(sender, args);
 		}
 		return true;
+	}
+
+	/**
+	 * Is called when a tab is pressed.  Should not be touched by any outside
+	 * plugin.
+	 * @param sender
+	 * @param cmd
+	 * @param args
+	 * @return
+	 */
+
+	public List<String> complete(CommandSender sender, org.bukkit.command.Command cmd, String[] args){
+		if (commands.containsKey(cmd.getName().toLowerCase())){
+			Command command = commands.get(cmd.getName().toLowerCase());
+			return command.tabComplete(sender, args);
+		}
+		return null;
 	}
 	/**
 	 * Sends a player help message.

--- a/src/vg/civcraft/mc/citadel/command/commands/Acid.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Acid.java
@@ -1,8 +1,6 @@
 package vg.civcraft.mc.citadel.command.commands;
 
-import java.util.Iterator;
-import java.util.Random;
-import java.util.UUID;
+import java.util.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -116,6 +114,11 @@ public class Acid extends PlayerCommand {
 			block.breakNaturally();
 		}
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return new ArrayList<String>();
 	}
 
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Bypass.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Bypass.java
@@ -7,6 +7,9 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Bypass extends PlayerCommand{
 
 	public Bypass(String name) {
@@ -31,6 +34,11 @@ public class Bypass extends PlayerCommand{
 		else 
 			p.sendMessage(ChatColor.GREEN + "Bypass mode has been disabled.");
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return new ArrayList<String>();
 	}
 
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
@@ -1,5 +1,7 @@
 package vg.civcraft.mc.citadel.command.commands;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -11,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
+import vg.civcraft.mc.citadel.command.commands.tabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
@@ -76,6 +79,20 @@ public class Fortification extends PlayerCommand{
 			state.setGroup(g);
 		}
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 0)
+			return GroupTabCompleter.complete(null, PermissionType.BLOCKS, (Player)sender);
+		else if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], PermissionType.BLOCKS, (Player)sender);
+		else{
+			return new ArrayList<String>();
+		}
 	}
 
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
@@ -13,7 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
-import vg.civcraft.mc.citadel.command.commands.tabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.citadel.command.tabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;

--- a/src/vg/civcraft/mc/citadel/command/commands/Information.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Information.java
@@ -8,6 +8,9 @@ import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Information extends PlayerCommand{
 
 	public Information(String name) {
@@ -36,6 +39,11 @@ public class Information extends PlayerCommand{
 			state.setMode(ReinforcementMode.REINFORCEMENT_INFORMATION);
 		}
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return new ArrayList<String>();
 	}
 
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Insecure.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Insecure.java
@@ -8,6 +8,9 @@ import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Insecure extends PlayerCommand{
 
 	public Insecure(String name) {
@@ -36,6 +39,11 @@ public class Insecure extends PlayerCommand{
 			state.setMode(ReinforcementMode.INSECURE);
 		}
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return new ArrayList<String>();
 	}
 
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Materials.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Materials.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.citadel.command.commands;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.ChatColor;
@@ -42,6 +43,11 @@ public class Materials extends PlayerCommand{
 		}
 		p.sendMessage(ChatColor.GREEN + t);
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return new ArrayList<String>();
 	}
 
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Off.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Off.java
@@ -7,6 +7,9 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Off extends PlayerCommand{
 
 	public Off(String name) {
@@ -30,6 +33,11 @@ public class Off extends PlayerCommand{
 			state.toggleBypassMode();
 		p.sendMessage(ChatColor.GREEN + "Reinforcement mode has been set to Normal.");
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return new ArrayList<String>();
 	}
 
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Reinforce.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Reinforce.java
@@ -1,5 +1,7 @@
 package vg.civcraft.mc.citadel.command.commands;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.ChatColor;
@@ -9,6 +11,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
+import vg.civcraft.mc.citadel.command.commands.tabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.group.Group;
@@ -62,6 +65,20 @@ public class Reinforce extends PlayerCommand {
 			state.setGroup(g);
 		}
 		return true;
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return null;
+
+		if (args.length == 0)
+			return GroupTabCompleter.complete(null, PermissionType.BLOCKS, (Player)sender);
+		else if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], PermissionType.BLOCKS, (Player)sender);
+		else {
+			return new ArrayList<String>();
+		}
 	}
 
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Reinforce.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Reinforce.java
@@ -11,7 +11,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
-import vg.civcraft.mc.citadel.command.commands.tabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.citadel.command.tabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.group.Group;

--- a/src/vg/civcraft/mc/citadel/command/commands/Stats.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Stats.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
+import vg.civcraft.mc.citadel.command.commands.tabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.group.Group;
 
@@ -62,7 +63,20 @@ public class Stats extends PlayerCommand{
 		Bukkit.getScheduler().runTaskAsynchronously(Citadel.getInstance(), new StatsMessage(p, g));
 		return true;
 	}
-	
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player))
+			return new ArrayList<String>();
+
+		if (args.length == 0)
+			return GroupTabCompleter.complete(null, null, (Player)sender);
+		else if (args.length == 1)
+			return GroupTabCompleter.complete(args[0], null, (Player)sender);
+		else return  new ArrayList<String>();
+
+	}
+
 	public class StatsMessage implements Runnable{
 
 		private final Player p;

--- a/src/vg/civcraft/mc/citadel/command/commands/Stats.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Stats.java
@@ -11,7 +11,7 @@ import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.command.PlayerCommand;
-import vg.civcraft.mc.citadel.command.commands.tabCompleters.GroupTabCompleter;
+import vg.civcraft.mc.citadel.command.tabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.group.Group;
 

--- a/src/vg/civcraft/mc/citadel/command/commands/tabCompleters/GroupTabCompleter.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/tabCompleters/GroupTabCompleter.java
@@ -1,0 +1,50 @@
+package vg.civcraft.mc.citadel.command.commands.tabCompleters;
+
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Created by isaac on 2/3/2015.
+ */
+public class GroupTabCompleter {
+    public static List<String> complete(String lastArg, PermissionType accessLevel, Player sender) {
+        UUID uuid = NameAPI.getUUID(sender.getName());
+        GroupManager gm = NameAPI.getGroupManager();
+        List<String> groups = gm.getAllGroupNames(uuid);
+        List<String> fitting_groups = new LinkedList<String>();
+        List<String> result = new LinkedList<String>();
+
+        if (lastArg != null){
+            for (String group : groups){
+                if (group.startsWith(lastArg)){
+                    fitting_groups.add(group);
+                } else {
+                }
+            }
+        } else {
+            fitting_groups = groups;
+        }
+
+        if (accessLevel == null) {
+            for (String group_name: fitting_groups){
+                Group group  = gm.getGroup(group_name);
+                if (group.isMember(uuid))
+                    result.add(group_name);
+            }
+        } else {
+            for (String group_name : fitting_groups) {
+                Group group = gm.getGroup(group_name);
+                if (gm.getPermissionforGroup(group).isAccessible(group.getPlayerType(uuid), accessLevel))
+                    result.add(group_name);
+            }
+        }
+        return result;
+    }
+}

--- a/src/vg/civcraft/mc/citadel/command/tabCompleters/GroupTabCompleter.java
+++ b/src/vg/civcraft/mc/citadel/command/tabCompleters/GroupTabCompleter.java
@@ -1,0 +1,50 @@
+package vg.civcraft.mc.citadel.command.tabCompleters;
+
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Created by isaac on 2/3/2015.
+ */
+public class GroupTabCompleter {
+    public static List<String> complete(String lastArg, PermissionType accessLevel, Player sender) {
+        UUID uuid = NameAPI.getUUID(sender.getName());
+        GroupManager gm = NameAPI.getGroupManager();
+        List<String> groups = gm.getAllGroupNames(uuid);
+        List<String> fitting_groups = new LinkedList<String>();
+        List<String> result = new LinkedList<String>();
+
+        if (lastArg != null){
+            for (String group : groups){
+                if (group.startsWith(lastArg)){
+                    fitting_groups.add(group);
+                } else {
+                }
+            }
+        } else {
+            fitting_groups = groups;
+        }
+
+        if (accessLevel == null) {
+            for (String group_name: fitting_groups){
+                Group group  = gm.getGroup(group_name);
+                if (group.isMember(uuid))
+                    result.add(group_name);
+            }
+        } else {
+            for (String group_name : fitting_groups) {
+                Group group = gm.getGroup(group_name);
+                if (gm.getPermissionforGroup(group).isAccessible(group.getPlayerType(uuid), accessLevel))
+                    result.add(group_name);
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
This is basically the same as my pull request for NameLayer. It auto completes the group name (from the groups where the user has the right permissions). @rourke750 does look ok? I was getting some sql exceptions [16:34:11] [Server thread/WARN]: com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: Unknown column 'ri.chunk_id' in 'where clause' but I'm assuming it isn't  anything to do with my code. Probably the tables are just out of date. Regardless I only committed the changes I made.