### PR TITLE
Added configuration options for water breaking

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -65,6 +65,14 @@ non_reinforceables:
  - VINE
  - NETHER_WARTS
  - ENDER_PORTAL
+non_washables:
+ - RAILS
+ - POWERED_RAIL
+ - ACTIVATOR_RAIL
+ - DETECTOR_RAIL
+ - REDSTONE_WIRE
+ - TRIPWIRE
+ - WEB
 reset_player_state: 300
 enable_maturation: true
 # The max amount of reinforcements to keep loaded

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: Citadel
 main: vg.civcraft.mc.citadel.Citadel
-version: 3.2.3
+version: 3.2.4
 author: Rourke750
 depend: [NameLayer]
 commands:

--- a/src/vg/civcraft/mc/citadel/Citadel.java
+++ b/src/vg/civcraft/mc/citadel/Citadel.java
@@ -19,6 +19,7 @@ import vg.civcraft.mc.citadel.listener.GroupsListener;
 import vg.civcraft.mc.citadel.listener.InventoryListener;
 import vg.civcraft.mc.citadel.listener.WorldListener;
 import vg.civcraft.mc.citadel.misc.CitadelStatics;
+import vg.civcraft.mc.citadel.misc.NonWashableType;
 import vg.civcraft.mc.citadel.reinforcementtypes.NaturalReinforcementType;
 import vg.civcraft.mc.citadel.reinforcementtypes.NonReinforceableType;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
@@ -46,6 +47,7 @@ public class Citadel extends JavaPlugin{
 		ReinforcementType.initializeReinforcementTypes();
 		NaturalReinforcementType.initializeNaturalReinforcementsTypes();
 		NonReinforceableType.initializeNonReinforceableTypes();
+		NonWashableType.initializeNonWashableTypes();
 		initializeDatabase();
 		
 		rm = new ReinforcementManager(db);

--- a/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
+++ b/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
@@ -40,6 +40,16 @@ public class CitadelConfigManager {
 		return nonReinforcementTypes;
 	}
 	
+	public static List<String> getNonWashableTypes() {
+		List<String> nonWashableTypes = new ArrayList<String>();
+		if(config.getStringList("non_washables") != null) {
+			for(String sect : config.getStringList("non_washables")) {
+				nonWashableTypes.add(sect);
+			}
+		}
+		return nonWashableTypes;
+	}
+	
 	public static int getRequireMents(String type){
 		return config.getInt("reinforcements." + type + ".requirements");
 	}

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -345,21 +345,7 @@ public class Utility {
         }
         return false;  // implicit isSecureable() == false
     }
-    /**
-     * Checks if it is a rail.
-     * @param The block in question.
-     * @return Returns true if it is a rail block.
-     */
-    public static boolean isRail(Block block) {
-        return isRail(block.getType());
-    }
-
-    private static boolean isRail(Material mat) {
-        return mat.equals(Material.RAILS)
-            || mat.equals(Material.POWERED_RAIL)
-            || mat.equals(Material.ACTIVATOR_RAIL)
-            || mat.equals(Material.DETECTOR_RAIL);
-    }
+    
     /**
      * Checks if a Redstone player is trying to power a block.
      * @param The Reinforcement in question.

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -5,7 +5,6 @@ import static vg.civcraft.mc.citadel.Utility.createPlayerReinforcement;
 import static vg.civcraft.mc.citadel.Utility.isAuthorizedPlayerNear;
 import static vg.civcraft.mc.citadel.Utility.isDroppedReinforcementBlock;
 import static vg.civcraft.mc.citadel.Utility.isPlant;
-import static vg.civcraft.mc.citadel.Utility.isRail;
 import static vg.civcraft.mc.citadel.Utility.maybeReinforcementDamaged;
 import static vg.civcraft.mc.citadel.Utility.reinforcementBroken;
 import static vg.civcraft.mc.citadel.Utility.reinforcementDamaged;
@@ -51,6 +50,7 @@ import vg.civcraft.mc.citadel.ReinforcementMode;
 import vg.civcraft.mc.citadel.Utility;
 import vg.civcraft.mc.citadel.events.ReinforcementCreationEvent;
 import vg.civcraft.mc.citadel.events.ReinforcementDamageEvent;
+import vg.civcraft.mc.citadel.misc.NonWashableType;
 import vg.civcraft.mc.citadel.misc.ReinforcemnetFortificationCancelException;
 import vg.civcraft.mc.citadel.reinforcement.PlayerReinforcement;
 import vg.civcraft.mc.citadel.reinforcement.Reinforcement;
@@ -300,7 +300,7 @@ public class BlockListener implements Listener{
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     public void onBlockFromToEvent(BlockFromToEvent event) {
         Block to_block = event.getToBlock();
-        if (!isRail(to_block) && !isPlant(to_block)) {
+        if (!NonWashableType.isNonWashable(to_block.getType()) && !isPlant(to_block)) {
             return;
         }
         Reinforcement rein = rm.getReinforcement(event.getToBlock());

--- a/src/vg/civcraft/mc/citadel/misc/NonWashableType.java
+++ b/src/vg/civcraft/mc/citadel/misc/NonWashableType.java
@@ -1,0 +1,23 @@
+package vg.civcraft.mc.citadel.misc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Material;
+
+import vg.civcraft.mc.citadel.CitadelConfigManager;
+
+public class NonWashableType {
+	public static List<Material> mats = new ArrayList<Material>();
+	
+	public static void initializeNonWashableTypes(){
+		List<String> materials = CitadelConfigManager.getNonWashableTypes();
+		for (String x: materials){
+			mats.add(Material.getMaterial(x));
+		}
+	}
+	
+	public static boolean isNonWashable(Material mat){
+		return mats.contains(mat);
+	}
+}


### PR DESCRIPTION
Currently a lot of reinforcements can be bypassed with water, this makes it configurable so water won't wash them away (default is rails, webs, redstone, and string)