### PR TITLE
Fix for dupe bug

### DIFF
--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -69,11 +69,15 @@ public class Utility {
         final int invSize = inv.getSize();
         final ItemStack itemType = type.getItemStack();
         List<Integer> slots = new ArrayList<Integer>(type.getRequiredAmount());
-        int requirements = type.getRequiredAmount();
-        if (requirements <= 0) {
+        int requirementscheck =  type.getRequiredAmount();
+        if (requirementscheck <= 0) {
             Citadel.Log("Reinforcement requirements too low for " + itemType.getType().name());
             return null;
         }
+        if (type.getMaterial().equals(block.getType())){
+        	requirementscheck++;
+        }
+        int requirements = requirementscheck;
         try {
             for (int slot = 0; slot < invSize && requirements > 0; ++slot) {
                 final ItemStack slotItem = inv.getItem(slot);
@@ -83,13 +87,13 @@ public class Utility {
                 if (!slotItem.isSimilar(itemType)) {
                     continue;
                 }
-                requirements -= slotItem.getAmount();
+                requirementscheck -= slotItem.getAmount();
                 slots.add(slot);
             }
         } catch (Exception ex) {
             // Eat any inventory size mis-match exceptions, like with the Anvil
         }
-        if (requirements > 0) {
+        if (requirementscheck > 0) {
             // Not enough reinforcement material
             return null;
         }
@@ -103,7 +107,15 @@ public class Utility {
         	throw new ReinforcemnetFortificationCancelException();
         }
         // Now eat the materials
-        requirements = type.getRequiredAmount();
+        
+        // Handle special case with block reinforcments.
+        if (type.getMaterial().isBlock()){
+	        if (slots.size()>1){
+	        	if (inv.getItemInHand().getType().equals(type.getMaterial()) && slots.get(0) != inv.getHeldItemSlot()){
+	        		requirements--;
+	        	}
+	        }
+        }
         for (final int slot : slots) {
             if (requirements <= 0) {
                 break;

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -105,8 +105,11 @@ public class BlockListener implements Listener{
             event.setCancelled(true);
             return;
         }
-        
-		if (inv.contains(type.getMaterial(), type.getRequiredAmount())) {
+        int required = type.getRequiredAmount();
+        if (type.getMaterial().equals(b.getType())){
+        	required++;
+        }
+		if (inv.contains(type.getMaterial(), required)) {
 			try {
 				if (createPlayerReinforcement(p, state.getGroup(), b, type) == null) {
 						p.sendMessage(ChatColor.RED + String.format("%s is not a reinforcible material ", b.getType().name()));


### PR DESCRIPTION
Addresses Civcraft/Citadel#99

In my research on the subject, i have narrowed down that the dupe when reinforcing stone is not a bug related to stone itself. It is a case that would happen to any reinforceable material that is also a place-able block. The only reason that is was limited to just stone blocks is because diamond and iron ingots are used for the other two reinforcement materials. But in my tests, any placeable block would have the same bug as stone currently does. I tested this by swapping stone with iron ore, and it had the same effect.

The two changes i have added, is to explicitly compare the block placed and reinforcement material to see if they are the same, and increment the values needed/removed by 1 to take into consideration the block placed.

