### PR TITLE
Fix for reinforced sand falling

### DIFF
--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -32,6 +32,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
 import org.bukkit.event.block.BlockFromToEvent;
+import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -579,5 +580,17 @@ public class BlockListener implements Listener{
     public void chunkLoadEvent(ChunkLoadEvent event) {
     	Chunk chunk = event.getChunk();
     	rm.loadReinforcementChunk(chunk);
+    }
+    
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void blockPhysEvent(BlockPhysicsEvent event){
+    	Block block = event.getBlock();
+    	if (block.getType().hasGravity()){
+    		Reinforcement rein = rm.getReinforcement(Utility.getRealBlock(block));
+    		if (rein != null){
+    			event.setCancelled(true);
+    		}
+    	}
+    	
     }
 }


### PR DESCRIPTION
Addresses Civcraft/Citadel#83

This pull makes citadel monitor blockphysics events. It checks if a block is affected by gravity(sand,gravel,anvil) then checks its reinforcement and cancels physics if the block is reinforced. This keeps reinforced sand from falling. It also fixes the weird glitchy-ness with reinforced gravity affected blocks disappearing or falling.

**Before patch:**
![](http://i.imgur.com/Mxm6kmp.png)
![](http://i.imgur.com/v7YlMyd.png)
![](http://i.imgur.com/SY9wg54.png)


**After patch:**
![](http://i.imgur.com/Mxm6kmp.png)
![](http://i.imgur.com/SvDRDLy.png)
![](http://i.imgur.com/YLMtsme.png)