### PR TITLE
Fix for reinforcement maturation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.3.6</version>
+	<version>3.3.7</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -293,8 +293,13 @@ public class Utility {
           if (maturationTime > 0 && type.getMaturationScale() != 0) {
         	  // the default amount of minutes it takes to mature
               int normal = type.getMaturationTime();
-              int percentTo = maturationTime / normal; // the percent of time left of maturation
-              durabilityLoss = durabilityLoss / percentTo * type.getMaturationScale();
+              if (maturationTime == normal) {
+                  durabilityLoss = durability;
+              } else {
+                  double percentTo = (double) maturationTime / (double) normal; // the percent of time left of maturation
+                  durabilityLoss = (int) (((double) durabilityLoss / (1.0d - percentTo)) * (double) type.getMaturationScale());
+              } // this new code scales smoothly between MaturationScale and a very large number, being closer to 
+              // MaturationScale the closer to "done" a maturation cycle
           }
           if (durability < durabilityLoss) {
               durabilityLoss = durability;
@@ -316,7 +321,7 @@ public class Utility {
     /**
      * Used to get the amount of time left until a reinforcement is mature.
      * @param Reinforcement.
-     * @return Returns 0 if it is mature or the time in seconds until it is mature.
+     * @return Returns 0 if it is mature or the time in minutes until it is mature.
      */
     public static int timeUntilMature(Reinforcement reinforcement) {
         // Doesn't explicitly save the updated Maturation time into the cache.


### PR DESCRIPTION
Prior was doing floating math using integers, Java truncates early and often with integer math so was always returning 0 leading to divide-by-zero exceptions. Plus the formula was wrong.

Fixed. Note this is a net-zero change for Civcraft's use (since we don't use maturation) but servers like Devoted or others that are trying to use maturation, this will save them a lot of headache.
