### PR TITLE
Acid maturation bifurcation

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@
 # requirements is the amount of the material needed to create a reinforcement.
 # return is the amount of material to return.
 # percent_chance is the chance to return the block. Scales with damage.
-# scale_amount is, if maturation is enabled, the amount extra to damage a block if it is not fully matured.  The forumla for calculating the extra damage is 1/((time left of maturation) / (default amount of time for maturation)) * scale.  So if a block has 5 minutes left of maturation on a 10 minute default period with a scale of 3 we do 1/(5 / 10) * 3 = 6 damage. Setting scale amount to 0 disables this function.
+# scale_amount is, if maturation is enabled, the amount extra to damage a block if it is not fully matured.  The forumla for calculating the extra damage is 1/(1-((time left of maturation) / (default amount of time for maturation))) * scale.  So if a block has 5 minutes left of maturation on a 10 minute default period with a scale of 3 we do 1/(5 / 10) * 3 = 6 damage. Setting scale amount to 0 disables this function.
 reinforcements:
  diamond:
   material: DIAMOND
@@ -12,7 +12,8 @@ reinforcements:
   hit_points: 1800
 # mature time is in minutes
   mature_time: 1440
-  scale_amount: 0
+  acid_time: 1440
+  scale_amount: 1
   lore:
 # Delete the comment char to use lore.  Three spaces are required 
 # after lore. You can add multiple lines by adding -
@@ -24,7 +25,8 @@ reinforcements:
   percent_chance: 100
   hit_points: 250
   mature_time: 60
-  scale_amount: 0
+  acid_time: 60
+  scale_amount: 1
   lore:
  stone:
   material: STONE
@@ -33,7 +35,8 @@ reinforcements:
   percent_chance: 100
   hit_points: 25
   mature_time: 10
-  scale_amount: 0
+  acid_time: 10
+  scale_amount: 1
   lore:
  bedrock:
   material: BEDROCK
@@ -42,7 +45,8 @@ reinforcements:
   percent_chance: 100
   hit_points: 2147483646
   mature_time: 2147483646
-  scale_amount: 0
+  acid_time: 2147483646
+  scale_amount: 1
   lore:
 #natural_reinforcements:
  #diamond_ore:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.3.6</version>
+	<version>3.3.8</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 

--- a/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
+++ b/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
@@ -63,6 +63,10 @@ public class CitadelConfigManager {
 	public static int getMaturationTime(String type){
 		return config.getInt("reinforcements." + type + ".mature_time");
 	}
+
+	public static int getAcidTime(String type) {
+		return config.getInt("reinforcements." + type + ".acid_time", getMaturationTime(type));
+	}
 	
 	public static int getMaturationScale(String type){
 		return config.getInt("reinforcements." + type + ".scale_amount");

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -95,7 +95,8 @@ public class Utility {
         }
         // Fire the creation event
         PlayerReinforcement rein = new PlayerReinforcement(block.getLocation(), 
-        		type.getHitPoints(), getIntFormofMaturation(System.currentTimeMillis(),type.getItemStack()), 
+        		type.getHitPoints(), getIntFormofMaturation(System.currentTimeMillis(),type.getItemStack()),
+        		getIntFormofAcidMaturation(System.currentTimeMillis(),type.getItemStack()),  
         		g, type.getItemStack(), g.getGroupId());
         ReinforcementCreationEvent event = new ReinforcementCreationEvent(rein, block, player);
         Bukkit.getPluginManager().callEvent(event);
@@ -147,7 +148,8 @@ public class Utility {
         	return null;
         }
 		PlayerReinforcement rein = new PlayerReinforcement(block.getLocation(), 
-        		type.getHitPoints(), getIntFormofMaturation(System.currentTimeMillis(),type.getItemStack()), 
+        		type.getHitPoints(), getIntFormofMaturation(System.currentTimeMillis(),type.getItemStack()),
+        		getIntFormofAcidMaturation(System.currentTimeMillis(),type.getItemStack()), 
         		g, type.getItemStack(), g.getGroupId());
         ReinforcementCreationEvent event = new ReinforcementCreationEvent(rein, block, player);
         Bukkit.getPluginManager().callEvent(event);
@@ -350,7 +352,7 @@ public class Utility {
                 final int curMinute = (int)(System.currentTimeMillis() / 60000L);
                 if (curMinute >= maturationTime) {
                     maturationTime = 0;
-                    reinforcement.setMaturationTime(0);
+                    reinforcement.setAcidTime(0);
                 } else {
                     maturationTime = maturationTime - curMinute;
                 }
@@ -535,8 +537,9 @@ public class Utility {
     		return null;
     	Group g = GroupManager.getSpecialCircumstanceGroup(group);
     	PlayerReinforcement rein = new PlayerReinforcement(loc, dur, 
-    			getIntFormofMaturation(System.currentTimeMillis(),reinType.getItemStack())
-    			, g, reinType.getItemStack(), g.getGroupId());
+    			getIntFormofMaturation(System.currentTimeMillis(),reinType.getItemStack()),
+        		getIntFormofAcidMaturation(System.currentTimeMillis(),reinType.getItemStack()),
+        		g, reinType.getItemStack(), g.getGroupId());
     	ReinforcementCreationEvent event = 
     			new ReinforcementCreationEvent(rein, loc.getBlock(), p);
     	Bukkit.getPluginManager().callEvent(event);
@@ -570,15 +573,16 @@ public class Utility {
     /**
      * Creates a MultiBlockReinforcement and saves it to the db. This method is to be used only be other plugins. Citadel 
      * will not use this anywhere. 
-     * @param locs- The locations that make up the structure.
-     * @param g- The group this will belong too.
-     * @param dur- The durability this structure will have.
-     * @param mature- The amount of time until it is mature (in minutes).
+     * @param locs The locations that make up the structure.
+     * @param g The group this will belong too.
+     * @param dur The durability this structure will have.
+     * @param mature The amount of time until it is mature (in minutes).
+     * @param acid The amount of time until it is mature (if acid -- in minutes).
      * @return
      */
-    public static MultiBlockReinforcement createMultiBlockReinforcement(List<Location> locs, Group g, int dur, int mature){
+    public static MultiBlockReinforcement createMultiBlockReinforcement(List<Location> locs, Group g, int dur, int mature, int acid){
     	int nextID = rm.getNextReinforcementID();
-    	MultiBlockReinforcement rein = new MultiBlockReinforcement(locs, g, dur, mature, nextID);
+    	MultiBlockReinforcement rein = new MultiBlockReinforcement(locs, g, dur, mature, acid, nextID);
     	ReinforcementCreationEvent event = new ReinforcementCreationEvent(rein, rein.getLocation().getBlock(), null);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
@@ -649,6 +653,14 @@ public class Utility {
 				.getMaturationTime();
 		return maturation;
 	}
+    
+    private static int getIntFormofAcidMaturation(long creation, ItemStack stack) {
+		int maturation = (int)(creation / 60000) + 
+				ReinforcementType.
+				getReinforcementType(stack)
+				.getAcidTime();
+		return maturation;
+    }
     
     public static Block findPlantSoil(Block block){
     	final Set<Material> soilTypes = getPlantSoilTypes(block.getType());

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -345,7 +345,7 @@ public class Utility {
         // Doesn't explicitly save the updated Acid Maturation time into the cache.
         //  That's the responsibility of the caller.
         if (reinforcement instanceof PlayerReinforcement){
-            int maturationTime = reinforcement.getAcidMaturationTime();
+            int maturationTime = reinforcement.getAcidTime();
             if (maturationTime > 0) {
                 final int curMinute = (int)(System.currentTimeMillis() / 60000L);
                 if (curMinute >= maturationTime) {
@@ -358,6 +358,7 @@ public class Utility {
             return (int) maturationTime; // should be small enough by now
         }
         return 0;
+	}
     
     /**
      * 

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -337,6 +337,29 @@ public class Utility {
         return 0;
     }
     /**
+     * Used to get the amount of time left until a reinforcement's acid component is mature.
+     * @param Reinforcement.
+     * @return Returns 0 if it is mature or the time in minutes until it is mature.
+     */
+    public static int timeUntilAcidMature(Reinforcement reinforcement) {
+        // Doesn't explicitly save the updated Acid Maturation time into the cache.
+        //  That's the responsibility of the caller.
+        if (reinforcement instanceof PlayerReinforcement){
+            int maturationTime = reinforcement.getAcidMaturationTime();
+            if (maturationTime > 0) {
+                final int curMinute = (int)(System.currentTimeMillis() / 60000L);
+                if (curMinute >= maturationTime) {
+                    maturationTime = 0;
+                    reinforcement.setMaturationTime(0);
+                } else {
+                    maturationTime = maturationTime - curMinute;
+                }
+            }
+            return (int) maturationTime; // should be small enough by now
+        }
+        return 0;
+    
+    /**
      * 
      * @param The Player who broke the reinforcement
      * @param The Reinforcement broken.

--- a/src/vg/civcraft/mc/citadel/command/commands/Acid.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Acid.java
@@ -97,8 +97,7 @@ public class Acid extends PlayerCommand {
 					.getReinforcementType(pRein.getStackRepresentation());
 			ReinforcementType topReinType = ReinforcementType
 					.getReinforcementType(pTopRein.getStackRepresentation());
-			if (acidBlockType.getMaturationTime() < topReinType
-					.getMaturationTime()) {
+			if (acidBlockType.getAcidTime() < topReinType.getAcidTime()) {
 				p.sendMessage(ChatColor.RED
 						+ "This acid block is too weak for that reinforcement.");
 				return true;

--- a/src/vg/civcraft/mc/citadel/command/commands/Acid.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Acid.java
@@ -72,9 +72,9 @@ public class Acid extends PlayerCommand {
 						+ "to use acid blocks.");
 				return true;
 			}
-			int time = Utility.timeUntilMature(pRein);
+			int time = Utility.timeUntilAcidMature(pRein);
 			if (time != 0) {
-				p.sendMessage(ChatColor.RED + "That block is not mature yet.");
+				p.sendMessage(ChatColor.RED + "That acid block is not mature yet.");
 				return true;
 			}
 			Block topFace = block.getRelative(BlockFace.UP);

--- a/src/vg/civcraft/mc/citadel/database/CitadelReinforcementData.java
+++ b/src/vg/civcraft/mc/citadel/database/CitadelReinforcementData.java
@@ -169,10 +169,10 @@ public class CitadelReinforcementData {
 			long first_time = System.currentTimeMillis();
 			Citadel.Log("Updating to version 8: The acid test. Note: This will take a while.");
 			db.execute("alter table reinforcement add acid_time int not null;"); 
-			db.execute("update reinformement set acid_time = maturation_time;"); // Might take a minute.
+			db.execute("update reinforcement set acid_time = maturation_time;"); // Might take a minute.
 			NameLayerPlugin.insertVersionNum(ver, plugin.getName());
 			ver = NameLayerPlugin.getVersionNum(plugin.getName());
-			Citadel.Log("The update to Version 7 took " + (System.currentTimeMillis() / first_time) / 1000 + " seconds.");
+			Citadel.Log("The update to Version 8 took " + (System.currentTimeMillis() / first_time) / 1000 + " seconds.");
 		}
 		Citadel.Log("The total time it took Citadel to update was " + 
 				(System.currentTimeMillis() - begin_time) / 1000 + " seconds.");

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -460,6 +460,17 @@ public class BlockListener implements Listener{
                             sb.append(maturationTime);
                             sb.append("]");
                         }
+						int acidTime = timeUntilAcidMature(reinforcement);
+						if (CitadelConfigManager.getAcidBlock() == block.getType()) {
+							sb.append(" Acid ");
+							if (acidTime != 0) {
+								sb.append("Immature[");
+								sb.append(acidTime);
+								sb.append("]");
+							} else {
+								sb.append("Mature");
+							}
+						}
                         if (reinforcement.isInsecure()) {
                             sb.append(" (Insecure)");
                         }
@@ -471,10 +482,10 @@ public class BlockListener implements Listener{
                         player.sendMessage(ChatColor.GREEN + sb.toString());
                     } else if(reinforcement.isAccessible(player, PermissionType.BLOCKS, PermissionType.DOORS, PermissionType.CHESTS)){
                         sb = new StringBuilder();
-                        boolean immature =
-                            timeUntilMature(reinforcement) != 0
-                            && (CitadelConfigManager.isMaturationEnabled()
-                                || CitadelConfigManager.getAcidBlock() == block.getType());
+                        boolean immature = timeUntilMature(reinforcement) != 0
+                            && CitadelConfigManager.isMaturationEnabled();
+						boolean acid = timeUntilAcidMature(reinforcement) != 0 
+							&& CitadelConfigManager.getAcidBlock() == block.getType();
                         String groupName = "!NULL!";
                         if (group != null) {
                             groupName = group.getName();
@@ -484,6 +495,9 @@ public class BlockListener implements Listener{
                         if(immature){
                             sb.append(" (Hardening)");
                         }
+						if(acid){
+							sb.append(" (Acid Maturing)");
+						}
                         if (reinforcement.isInsecure()) {
                             sb.append(" (Insecure)");
                         }

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -9,6 +9,7 @@ import static vg.civcraft.mc.citadel.Utility.maybeReinforcementDamaged;
 import static vg.civcraft.mc.citadel.Utility.reinforcementBroken;
 import static vg.civcraft.mc.citadel.Utility.reinforcementDamaged;
 import static vg.civcraft.mc.citadel.Utility.timeUntilMature;
+import static vg.civcraft.mc.citadel.Utility.timeUntilAcidMature;
 import static vg.civcraft.mc.citadel.Utility.wouldPlantDoubleReinforce;
 
 import java.util.Arrays;

--- a/src/vg/civcraft/mc/citadel/reinforcement/MultiBlockReinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/MultiBlockReinforcement.java
@@ -18,8 +18,8 @@ public class MultiBlockReinforcement extends Reinforcement{
 			new HashMap<Integer, MultiBlockReinforcement>();
 	
 	public MultiBlockReinforcement(List<Location> locs, Group g, int dur, 
-			int creation, int multiBlockId) {
-		super(null, null, dur, creation);
+			int creation, int acid, int multiBlockId) {
+		super(null, null, dur, creation, acid);
 		this.g = g;
 		this.locs = locs;
 		reins.put(multiBlockId, this);

--- a/src/vg/civcraft/mc/citadel/reinforcement/NaturalReinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/NaturalReinforcement.java
@@ -5,7 +5,7 @@ import org.bukkit.block.Block;
 public class NaturalReinforcement extends Reinforcement{
 	
 	public NaturalReinforcement(Block block, int dur){
-		super(block.getLocation(), block.getType(), dur, 0);
+		super(block.getLocation(), block.getType(), dur, 0, 0);
 		// The group is null be natural reinforcements don't belong to a group.
 	}
 }

--- a/src/vg/civcraft/mc/citadel/reinforcement/NullReinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/NullReinforcement.java
@@ -8,6 +8,6 @@ import org.bukkit.Location;
 public class NullReinforcement extends Reinforcement{
 
 	public NullReinforcement(Location loc) {
-		super(loc, null, 0, 0);
+		super(loc, null, 0, 0, 0);
 	}
 }

--- a/src/vg/civcraft/mc/citadel/reinforcement/PlayerReinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/PlayerReinforcement.java
@@ -28,8 +28,8 @@ public class PlayerReinforcement extends Reinforcement{
 	private ItemStack stack;
 	
 	public PlayerReinforcement(Location loc, int health,
-			int creation, Group g, ItemStack stack, int group_id) {
-		super(loc, stack.getType(), health, creation);
+			int creation, int acid, Group g, ItemStack stack, int group_id) {
+		super(loc, stack.getType(), health, creation, acid);
 		this.g = g;
 		this.stack = stack;
 		gp = NameAPI.getGroupManager().getPermissionforGroup(g);

--- a/src/vg/civcraft/mc/citadel/reinforcement/Reinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/Reinforcement.java
@@ -6,16 +6,18 @@ import org.bukkit.Material;
 public class Reinforcement {
 
 	private int creation;
+	private int acid;
 	private Location loc;
 	private Material mat;
 	private int dur;
 	protected boolean isDirty;
 	
-	public Reinforcement(Location loc, Material mat, int dur, int creation){
+	public Reinforcement(Location loc, Material mat, int dur, int creation, int acid){
 		this.loc = loc;
 		this.mat = mat;
 		this.dur = dur;
 		this.creation = creation;
+		this.acid = acid;
 		isDirty = false;
 	}
 	/**
@@ -52,10 +54,24 @@ public class Reinforcement {
 	}
 	/**
 	 * Sets the maturation time of this reinforcement.
-	 * @param The time in seconds it was created.
+	 * @param The time in minutes it was created.
 	 */
 	public void setMaturationTime(int time){
 		creation = time;
+		isDirty = true;
+	}
+	/**
+	 * @return Returns the time that this acid process began or 0 if not acid/done.
+	 */
+	public int getAcidTime(){
+		return acid;
+	}
+	/**
+	 * Sets the acid process time of this reinforcement (0 to indicate done/not acid).
+	 * @param The time in minutes acid process began.
+	 */
+	public void setAcidTime(int acid) {
+		this.acid = acid;
 		isDirty = true;
 	}
 	/**

--- a/src/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementType.java
+++ b/src/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementType.java
@@ -19,6 +19,7 @@ public class ReinforcementType {
 	private int hitpoints;
 	private Material mat;
 	private int maturationTime;
+	private int acidTime;
 	private int scale;
 	private ItemStack stack;
 	
@@ -26,14 +27,15 @@ public class ReinforcementType {
 			new HashMap<ItemStack, ReinforcementType>();
 	
 	public ReinforcementType(Material mat, int amount, double percentReturn,
-			int returnValue, int hitpoints, int maturationTime, int scale,
-			List<String> lore) {
+			int returnValue, int hitpoints, int maturationTime, int acidTime,
+			int scale, List<String> lore) {
 		this.mat = mat;
 		this.amount = amount;
 		this.percentReturn = percentReturn/100;
 		this.returnValue = returnValue;
 		this.hitpoints = hitpoints;
 		this.maturationTime = maturationTime;
+		this.acidTime = acidTime;
 		this.scale = scale;
 		ItemStack stack = new ItemStack(mat, amount);
 		ItemMeta meta = stack.getItemMeta();
@@ -52,10 +54,11 @@ public class ReinforcementType {
 			int returnValue = CitadelConfigManager.getReturns(type);
 			int hitpoints = CitadelConfigManager.getHitPoints(type);
 			int maturation = CitadelConfigManager.getMaturationTime(type);
+			int acid = CitadelConfigManager.getAcidTime(type);
 			int maturation_scale = CitadelConfigManager.getMaturationScale(type);
 			List<String> lore = CitadelConfigManager.getLoreValues(type);
 			new ReinforcementType(mat, amount, percentReturn, returnValue,
-					hitpoints, maturation, maturation_scale, lore);
+					hitpoints, maturation, acid, maturation_scale, lore);
 		}
     }
 	/**
@@ -93,6 +96,12 @@ public class ReinforcementType {
 	 */
 	public int getMaturationTime(){
 		return maturationTime;
+	}
+	/**
+	 * @return Returns the Acid time needed until this acid block is ready.
+	 */
+	public int getAcidTime() {
+		return acidTime;
 	}
 	/**
 	 * @return Get the scale of amount of damage a block should take when it is not fully mature.


### PR DESCRIPTION
Don't merge -- for discussion.


One thing that comes up when using maturation is that having acid time the same as block maturation is ... well, really inconvenient. 

Let's say you want to have block maturation of 20 minutes, but acid time of 1 day. Can't. Have to have acid time of 20 minutes, which might as well be instant break.

In any case, to have usable acid w/ maturation, they need to be separate timers.

This pull represents that change. I'm putting it here to facilitate discussion and make sure I covered all my bases in the change. It compiles but I haven't tested it -- that's next up. 

@rourke750 when you get a few spare cycles, would love you to look over and advise.