### PR TITLE
Fix for double consumption of stone  &  critical DB fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.3.8</version>
+	<version>3.3.9</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -51,11 +51,12 @@ public class Utility {
 	 * @param The Group this reinforcement belongs too.
 	 * @param The Block this reinforcement is occurring on.
 	 * @param The ReinforcementType that is being reinforced on the block.
+	 * @param The ItemStack type of the block being placed (if CTF, null if CTR)
 	 * @return The PlayerReinforcement that comes from these parameters or null if certain checks failed.
 	 * @throws ReinforcemnetFortificationCancelException
 	 */
 	public static PlayerReinforcement createPlayerReinforcement(Player player, Group g, Block block,
-			ReinforcementType type) {
+			ReinforcementType type, ItemStack reinfMat) {
         if (g.isDisciplined()) {
             player.sendMessage(ChatColor.RED + "This group is disiplined.");
             return null;
@@ -74,7 +75,7 @@ public class Utility {
             Citadel.Log("Reinforcement requirements too low for " + itemType.getType().name());
             return null;
         }
-        if (type.getMaterial().equals(block.getType())){
+        if (reinfMat != null && itemType.isSimilar(reinfMat)){ // only in CTF.
         	requirementscheck++;
         }
         int requirements = requirementscheck;
@@ -108,10 +109,10 @@ public class Utility {
         }
         // Now eat the materials
         
-        // Handle special case with block reinforcments.
+        // Handle special case with block reinforcements.
         if (type.getMaterial().isBlock()){
 	        if (slots.size()>1){
-	        	if (inv.getItemInHand().getType().equals(type.getMaterial()) && slots.get(0) != inv.getHeldItemSlot()){
+	        	if (inv.getItemInHand().isSimilar(itemType) && slots.get(0) != inv.getHeldItemSlot()){
 	        		requirements--;
 	        	}
 	        }

--- a/src/vg/civcraft/mc/citadel/database/CitadelReinforcementData.java
+++ b/src/vg/civcraft/mc/citadel/database/CitadelReinforcementData.java
@@ -661,7 +661,7 @@ public class CitadelReinforcementData {
 			return lastId;
 		}
 		try {
-			PreparedStatement updateRein = db.prepareStatement(this.updateRein);
+			PreparedStatement updateRein = db.prepareStatement(this.getLastReinID);
 			ResultSet set = updateRein.executeQuery();
 			set.next();
 			lastId = set.getInt(1);

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -107,12 +107,12 @@ public class BlockListener implements Listener{
             return;
         }
         int required = type.getRequiredAmount();
-        if (type.getMaterial().equals(b.getType())){
+        if (type.getItemStack().isSimilar(event.getItemInHand())){
         	required++;
         }
-		if (inv.contains(type.getMaterial(), required)) {
+		if (inv.containsAtLeast(type.getItemStack(), required)) {
 			try {
-				if (createPlayerReinforcement(p, state.getGroup(), b, type) == null) {
+				if (createPlayerReinforcement(p, state.getGroup(), b, type, event.getItemInHand()) == null) {
 						p.sendMessage(ChatColor.RED + String.format("%s is not a reinforcible material ", b.getType().name()));
 				} else {
 					state.checkResetMode();
@@ -542,7 +542,7 @@ public class BlockListener implements Listener{
                     } else {
                     	try {
                         createPlayerReinforcement(player, state.getGroup(),
-                        		block, state.getReinforcementType());
+                        		block, state.getReinforcementType(), null);
                     	}catch(ReinforcemnetFortificationCancelException e){
                     		Citadel.Log("ReinforcementFortificationCancelException occured in BlockListener, PlayerInteractEvent " + e.getStackTrace());
                     	}


### PR DESCRIPTION
when placing stone variants during CTF or CTR. Includes critical DB call fix that is in the unmerged Acid update.

Basically, we had reports that when stone-reinforcing Stone variants (granite, etc.) stone would be  doubleconsumed. This is the result of the fix #136 for _under_consumption of stone during CTF. Basically the fix just looked at Material instead of using the ItemStack type. There might be a more elegant way to do this but I've got it on CivTest right now and it's working, but only in Gamemode 0. Gamemode 1 refunds the cost for some reason; given that no-body but ops use gamemode 1, I don't think it's a big deal.

Note on the DB call fix; rourke had introduced a typo while updating the DB calls. This incorporates that fix as I was violently reminded of the bug when I loaded the unpatched version up on Civtest. Civtest's DB has been fixed, and the "fix" introduced here in the hopes it will be merged sooner rather the nlater.