### PR TITLE
Added support for exclusive reinforcement types 

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,10 @@ reinforcements:
 # Delete the comment char to use lore.  Three spaces are required 
 # after lore. You can add multiple lines by adding -
 #   - Some string representation required for this reinforcement.
+#
+# # Uncomment below to add limits to what blocks this reinforcement can be applied to
+# reinforceables:
+#   - STONE
  iron:
   material: IRON_INGOT
   requirements: 1

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.4.35</version>
+	<version>3.4.36</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 

--- a/src/vg/civcraft/mc/citadel/Citadel.java
+++ b/src/vg/civcraft/mc/citadel/Citadel.java
@@ -19,6 +19,7 @@ import vg.civcraft.mc.citadel.listener.GroupsListener;
 import vg.civcraft.mc.citadel.listener.InventoryListener;
 import vg.civcraft.mc.citadel.listener.WorldListener;
 import vg.civcraft.mc.citadel.misc.CitadelStatics;
+import vg.civcraft.mc.citadel.reinforcementtypes.ExclusiveReinforcementType;
 import vg.civcraft.mc.citadel.reinforcementtypes.NaturalReinforcementType;
 import vg.civcraft.mc.citadel.reinforcementtypes.NonReinforceableType;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
@@ -46,6 +47,7 @@ public class Citadel extends JavaPlugin{
 		ReinforcementType.initializeReinforcementTypes();
 		NaturalReinforcementType.initializeNaturalReinforcementsTypes();
 		NonReinforceableType.initializeNonReinforceableTypes();
+		ExclusiveReinforcementType.initializeExclusiveReinforcementTypes();
 		initializeDatabase();
 		
 		rm = new ReinforcementManager(db);

--- a/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
+++ b/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
@@ -20,6 +20,13 @@ public class CitadelConfigManager {
 		return reinforcementTypes;
 	}
 	
+	public static List<String> getReinforceableMaterials(String mat){
+		if(config.getConfigurationSection("reinforcements." + mat).contains("reinforceables")) {
+			return config.getConfigurationSection("reinforcements." + mat).getStringList("reinforceables");
+		}
+		return null;
+	}
+	
 	public static List<String> getNaturalReinforcementTypes(){
 		List<String> naturalReinforcementTypes = new ArrayList<String>();
 		if (config.getConfigurationSection("natural_reinforcements") == null)

--- a/src/vg/civcraft/mc/citadel/command/commands/AreaReinforce.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/AreaReinforce.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.ReinforcementManager;
 import vg.civcraft.mc.citadel.Utility;
+import vg.civcraft.mc.citadel.reinforcementtypes.ExclusiveReinforcementType;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.NameAPI;
@@ -99,6 +100,11 @@ public class AreaReinforce extends PlayerCommand {
 							.getBlockAt(x, y, z));
 					if (!(current.getType() == Material.AIR) && !rm.isReinforced(current) 
 							&& !Utility.wouldPlantDoubleReinforce(current)) {				
+						if (!ExclusiveReinforcementType.canReinforce(rt.getMaterial(), current.getType())) {
+							p.sendMessage(ChatColor.RED + "The block at " + x + ", " + y + ", " + z + 
+									" was not reinforced because the material type you are using cannot reinforce that type of block.");
+							continue;
+						}
 						Utility.createPlayerReinforcementWithoutMaterialConsumption(p, g, current, rt);
 					}
 				}

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -57,6 +57,7 @@ import vg.civcraft.mc.citadel.events.ReinforcementDamageEvent;
 import vg.civcraft.mc.citadel.misc.ReinforcemnetFortificationCancelException;
 import vg.civcraft.mc.citadel.reinforcement.PlayerReinforcement;
 import vg.civcraft.mc.citadel.reinforcement.Reinforcement;
+import vg.civcraft.mc.citadel.reinforcementtypes.ExclusiveReinforcementType;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.group.GroupType;
@@ -104,6 +105,12 @@ public class BlockListener implements Listener{
 		 // Don't allow double reinforcing reinforceable plants
         if (wouldPlantDoubleReinforce(b)) {
             p.sendMessage(ChatColor.RED + "Cancelled block place, crop would already be reinforced.");
+            event.setCancelled(true);
+            return;
+        }
+        // Don't allow incorrect reinforcement with exclusive reinforcement types
+        if (!ExclusiveReinforcementType.canReinforce(type.getMaterial(), b.getType())) {
+            p.sendMessage(ChatColor.RED + "That material cannot reinforce that type of block. Try a different reinforcement material.");
             event.setCancelled(true);
             return;
         }
@@ -542,6 +549,13 @@ public class BlockListener implements Listener{
                 	ReinforcementType type = ReinforcementType.getReinforcementType(stack);
                 	if (type == null){
                 		player.sendMessage(ChatColor.RED + stack.getType().name() + " is not a reinforcable material.");
+                		player.sendMessage(ChatColor.RED + "Left Reinforcement mode.");
+                		state.reset();
+                		return;
+                	}
+                	// Don't allow incorrect reinforcement with exclusive reinforcement types
+                	if (!ExclusiveReinforcementType.canReinforce(type.getMaterial(), block.getType())) {
+                		player.sendMessage(ChatColor.RED + "That material cannot reinforce that type of block. Try a different reinforcement material.");
                 		player.sendMessage(ChatColor.RED + "Left Reinforcement mode.");
                 		state.reset();
                 		return;

--- a/src/vg/civcraft/mc/citadel/reinforcementtypes/ExclusiveReinforcementType.java
+++ b/src/vg/civcraft/mc/citadel/reinforcementtypes/ExclusiveReinforcementType.java
@@ -1,0 +1,56 @@
+package vg.civcraft.mc.citadel.reinforcementtypes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Material;
+
+import vg.civcraft.mc.citadel.CitadelConfigManager;
+
+//An ExclusiveReinforcementType is a reinforcement type that can only reinforce certain blocks
+//For example, maybe you want players to be able to reinforce chests with emeralds,
+//but unable to reinforce obsidian with emeralds
+public class ExclusiveReinforcementType {
+
+	public static Map<Material, List<Material>> mats = new HashMap<Material, List<Material>>();
+	
+	public static void initializeExclusiveReinforcementTypes() {
+		for(String reinforcementType : CitadelConfigManager.getReinforcementTypes()) {
+			Material mat = CitadelConfigManager.getMaterial(reinforcementType);
+			List<String> canReinforceNames = CitadelConfigManager.getReinforceableMaterials(reinforcementType);
+			if(canReinforceNames == null) {
+				continue;
+			}
+			List<Material> canReinforce = new ArrayList<Material>();
+			for(String s : canReinforceNames) {
+				canReinforce.add(Material.getMaterial(s));
+			}
+			//Check if the reinforcement type is meant to be exclusive
+			if(!canReinforce.isEmpty()) {
+				mats.put(mat, canReinforce);
+			}
+		}
+	}
+	
+	public static boolean isExclusive(Material mat) {
+		return mats.containsKey(mat);
+	}
+	
+	public static List<Material> getReinforceableMaterials(Material mat) {
+		return mats.get(mat);
+	}
+	
+	/**
+	 * Returns whether or not a given material can be used to reinforce another material
+	 * @param The material to reinforce with
+	 * @param The material to be reinforced
+	 */
+	public static boolean canReinforce(Material reinforcer, Material reinforcee) {
+		if(!isExclusive(reinforcer)) {
+			return true;
+		}
+		return mats.get(reinforcer).contains(reinforcee);
+	}
+}


### PR DESCRIPTION
By Soerxpso -- upstream contrib from Devotion.

Allows locking specific reinforcement types to be used only with certain blocks.

Very useful.

Tested a bit on our test rig, about to go live on Devoted main.