### PR TITLE
Decreasing location precision to make the cache work better (not tested)

### DIFF
--- a/src/vg/civcraft/mc/citadel/ReinforcementManager.java
+++ b/src/vg/civcraft/mc/citadel/ReinforcementManager.java
@@ -26,6 +26,19 @@ public class ReinforcementManager {
 
 	private CitadelReinforcementData db;
 
+	/*
+		By reducing the precision of the Location the LoadingCache should have more hits for the same block.
+	*/
+	private Location reduceLocationPrecisionToInt(Location loc)
+	{
+		return new Location(
+				loc.getWorld(),
+				(double)loc.getBlockX(),
+				(double)loc.getBlockY(),
+				(double)loc.getBlockZ()
+		);
+	}
+
 	// This shit is cool
 	private RemovalListener<Location, Reinforcement> removalListener = new RemovalListener<Location, Reinforcement>() {
 		public void onRemoval(
@@ -82,7 +95,7 @@ public class ReinforcementManager {
 		// but it got this far.  Lets just keep the one already there and ignore this new one.
 		// If this is some other case then the code already in place should have deleted the reinforcement EX: Air.
 		if (getReinforcement(rein.getLocation()) == null) {
-			reinforcements.put(rein.getLocation(), rein);
+			reinforcements.put(reduceLocationPrecisionToInt(rein.getLocation()), rein);
 			CitadelStatics.updateHitStat(CitadelStatics.INSERT);
 			db.insertReinforcement(rein);
 		}
@@ -96,7 +109,7 @@ public class ReinforcementManager {
 	 */
 	public Reinforcement getReinforcement(Location loc) {
 		try {
-			Reinforcement rein = reinforcements.get(loc);
+			Reinforcement rein = reinforcements.get(reduceLocationPrecisionToInt(loc));
 			if (rein instanceof NullReinforcement)
 				return null;
 			CitadelStatics.updateHitStat(CitadelStatics.CACHE);
@@ -125,7 +138,7 @@ public class ReinforcementManager {
 	 * @param rein
 	 */
 	public void deleteReinforcement(Reinforcement rein) {
-		reinforcements.invalidate(rein.getLocation());
+		reinforcements.invalidate(reduceLocationPrecisionToInt(rein.getLocation());
 		CitadelStatics.updateHitStat(CitadelStatics.DELETE);
 		db.deleteReinforcement(rein);
 	}
@@ -187,14 +200,14 @@ public class ReinforcementManager {
 		List<Reinforcement> reins = db.getReinforcements(chunk);
 		List<Reinforcement> reins_new = new ArrayList<Reinforcement>();
 		for (Reinforcement rein: reins){
-			if (reinforcements.getIfPresent(rein.getLocation()) == null){
-				reinforcements.put(rein.getLocation(), rein);
+			if (reinforcements.getIfPresent(reduceLocationPrecisionToInt(rein.getLocation())) == null){
+				reinforcements.put(reduceLocationPrecisionToInt(rein.getLocation()), rein);
 				reins_new.add(rein);
 			}
 			else {
 				Reinforcement r = null;
 				try {
-					r = reinforcements.get(rein.getLocation());
+					r = reinforcements.get(reduceLocationPrecisionToInt(rein.getLocation()));
 				} catch (ExecutionException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
@@ -208,9 +221,9 @@ public class ReinforcementManager {
 	public void loadReinforcementChunk(Chunk chunk) {
 		List<Reinforcement> reins = db.getReinforcements(chunk);
 		for (Reinforcement rein: reins){
-			Reinforcement r = reinforcements.getIfPresent(rein.getLocation());
+			Reinforcement r = reinforcements.getIfPresent(reduceLocationPrecisionToInt(rein.getLocation()));
 			if (r == null || r instanceof NullReinforcement) {
-				reinforcements.put(rein.getLocation(), rein);
+				reinforcements.put(reduceLocationPrecisionToInt(rein.getLocation()), rein);
 			}
 		}
 	}

--- a/src/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -137,8 +137,10 @@ public class BlockListener implements Listener{
 		Block reinforcingBlock = null;
 		Reinforcement rein = rm.getReinforcement(Utility.getRealBlock(block));
 		
+        boolean isBlockPlant = isPlant(block);
+
 		//if block is a plant check reinforcement on soil block
-		if(isPlant(block)){
+		if(isBlockPlant){
         	reinforcingBlock = Utility.findPlantSoil(block);
         	Reinforcement plant = null;
         	if (reinforcingBlock != null)
@@ -148,7 +150,7 @@ public class BlockListener implements Listener{
 		}
 
 		if (rein == null){
-			rein = createNaturalReinforcement(event.getBlock(), player);
+			rein = createNaturalReinforcement(block, player);
 			if (rein != null){
 				ReinforcementDamageEvent e = new ReinforcementDamageEvent(rein, player, block);
 				Bukkit.getPluginManager().callEvent(e);
@@ -168,7 +170,7 @@ public class BlockListener implements Listener{
             PlayerReinforcement pr = (PlayerReinforcement) rein;
             PlayerState state = PlayerState.get(player);
             boolean admin_bypass = player.hasPermission("citadel.admin.bypassmode");   
-            if (reinforcingBlock != null && isPlant(block) && (pr.isAccessible(player, PermissionType.CROPS) || admin_bypass)) {
+            if (reinforcingBlock != null && isBlockPlant && (pr.isAccessible(player, PermissionType.CROPS) || admin_bypass)) {
                 //player has CROPS access to the soil block, allow them to break without affecting reinforcement
             	is_cancelled = false;
             } else if (state.isBypassMode() && (pr.isBypassable(player) || admin_bypass) && !pr.getGroup().isDisciplined()) {
@@ -250,10 +252,11 @@ public class BlockListener implements Listener{
     private static final Material matfire = Material.FIRE;
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
     public void blockBurn(BlockBurnEvent bbe) {
-        boolean wasprotected = maybeReinforcementDamaged(bbe.getBlock());
+        Block block = bbe.getBlock();
+        boolean wasprotected = maybeReinforcementDamaged(block);
         if (wasprotected) {
             bbe.setCancelled(wasprotected);
-        Block block = bbe.getBlock();
+            
             // Basic essential fire protection
             if (block.getRelative(0,1,0).getType() == matfire) {block.getRelative(0,1,0).setTypeId(0);} // Essential
             // Extended fire protection (recommend)


### PR DESCRIPTION
I think adding a function such I did in this pull request should make the caching more efficient, it removes the digits after the decimal point in order to make the .equal() function (and .hashCode()) to work for 2 different Location objects with the same integer XYZ coordinates.
This should save some SQL queries on blockchange events preventing the Main thread from freezing.

Greets,