### PR TITLE
Instrumenting proper logging for player actions

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,10 @@
 # return is the amount of material to return.
 # percent_chance is the chance to return the block. Scales with damage.
 # scale_amount is, if maturation is enabled, the amount extra to damage a block if it is not fully matured.  The forumla for calculating the extra damage is 1/(1-((time left of maturation) / (default amount of time for maturation))) * scale.  So if a block has 5 minutes left of maturation on a 10 minute default period with a scale of 3 we do 1/(5 / 10) * 3 = 6 damage. Setting scale amount to 0 disables this function.
+internal_logging: true
+command_logging: true
+break_logging: true
+reinf_logging: false
 reinforcements:
  diamond:
   material: DIAMOND

--- a/plugin.yml
+++ b/plugin.yml
@@ -29,6 +29,9 @@ commands:
  ctar:
   permission: citadel.admin
   aliases: [ctareareinforce] 
+ ctsl:
+  permission: citadel.admin
+  aliases: [ctsetlogging]
 permissions:
  citadel.admin:
   default: op

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>3.4.42</version>
+	<version>3.4.43</version>
 	<name>Citadel</name>
 	<url>https://github.com/Civcraft/Citadel</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>2.3.2</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/src/vg/civcraft/mc/citadel/Citadel.java
+++ b/src/vg/civcraft/mc/citadel/Citadel.java
@@ -7,7 +7,6 @@ import java.util.logging.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import vg.civcraft.mc.citadel.command.CommandHandler;
@@ -22,7 +21,6 @@ import vg.civcraft.mc.citadel.misc.CitadelStatics;
 import vg.civcraft.mc.citadel.reinforcementtypes.NaturalReinforcementType;
 import vg.civcraft.mc.citadel.reinforcementtypes.NonReinforceableType;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
-import vg.civcraft.mc.namelayer.NameLayerPlugin;
 
 public class Citadel extends JavaPlugin{
 	private static Logger logger;

--- a/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
+++ b/src/vg/civcraft/mc/citadel/CitadelConfigManager.java
@@ -140,4 +140,20 @@ public class CitadelConfigManager {
 	public static String getPassword(){
 		return config.getString("mysql.password", "");
 	}
+
+	public static boolean shouldLogInternal() {
+		return config.getBoolean("internal_logging", false);
+	}
+
+	public static boolean shouldLogPlayerCommands() {
+		return config.getBoolean("command_logging", false);
+	}
+
+	public static boolean shouldLogBreaks() {
+		return config.getBoolean("break_logging", false);
+	}
+
+	public static boolean shouldLogReinforcement() {
+		return config.getBoolean("reinf_logging", false);
+	}
 }

--- a/src/vg/civcraft/mc/citadel/PlayerState.java
+++ b/src/vg/civcraft/mc/citadel/PlayerState.java
@@ -3,6 +3,7 @@ package vg.civcraft.mc.citadel;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -26,6 +27,9 @@ public class PlayerState {
      * @return The PlayerState of that player.
      */
     public static PlayerState get(Player player) {
+    	if (player == null) {
+    		Citadel.getInstance().getLogger().log(Level.WARNING, "PlayerState get called with null player");
+    	}
         UUID id = NameAPI.getUUID(player.getName());
         PlayerState state = PLAYER_STATES.get(id);
         if (state == null) {
@@ -36,6 +40,9 @@ public class PlayerState {
     }
     
     public static PlayerState get(UUID id) {
+    	if (id == null) {
+    		Citadel.getInstance().getLogger().log(Level.WARNING, "PlayerState get called with null id");
+    	}
     	PlayerState state = PLAYER_STATES.get(id);
         if (state == null) {
             state = new PlayerState(id);
@@ -54,7 +61,6 @@ public class PlayerState {
 
     private UUID accountId;
     private ReinforcementMode mode;
-    private Material fortificationMaterial;
     private Group faction;
     private boolean bypassMode;
     private Integer cancelModePid;
@@ -75,7 +81,6 @@ public class PlayerState {
      */
     public void reset() {
         mode = ReinforcementMode.NORMAL;
-        fortificationMaterial = null;
         fortificationStack = null;
         faction = null;
     }
@@ -99,7 +104,9 @@ public class PlayerState {
      * @param ItemStack.
      */
     public void setFortificationItemStack(ItemStack fortificationStack) {
-        this.fortificationMaterial = fortificationStack.getType();
+    	if (fortificationStack == null) {
+    		Citadel.getInstance().getLogger().log(Level.WARNING, "PlayerState setFortificationItemStack called with null stack");
+    	}
         this.fortificationStack = fortificationStack;
     }
     /**
@@ -114,6 +121,9 @@ public class PlayerState {
      * @param The group.
      */
     public void setGroup(Group faction) {
+    	if (faction == null) {
+    		Citadel.getInstance().getLogger().log(Level.WARNING, "PlayerState setGroup called with null faction");
+    	}
         this.faction = faction;
     }
     /**
@@ -146,11 +156,15 @@ public class PlayerState {
         
         cancelModePid = scheduler.scheduleSyncDelayedTask(plugin, new Runnable() {
             public void run() {
-                Player player = Bukkit.getPlayer(accountId);
-                if (player != null) {
-                    player.sendMessage(ChatColor.YELLOW + mode.name() + " mode off");
-                }
-                reset();
+            	try {
+	                Player player = Bukkit.getPlayer(accountId);
+	                if (player != null) {
+	                    player.sendMessage(ChatColor.YELLOW + mode.name() + " mode off");
+	                }
+	                reset();
+            	} catch (Exception e) {
+               		Citadel.getInstance().getLogger().log(Level.WARNING, "PlayerState checkResetMode Failed", e);
+            	}
             }
         }, 20L * CitadelConfigManager.getPlayerStateReset());
     }

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -59,10 +59,10 @@ public class Utility {
      */
     public static PlayerReinforcement createPlayerReinforcement(Player player, Group g, Block block,
             ReinforcementType type, ItemStack reinfMat) {
-		if (player == null || g == null || block == null || type == null || reinfMat == null) {
+		if (player == null || g == null || block == null || type == null) {
 			Citadel.getInstance().getLogger().log(Level.WARNING,
-					"Utility createPlayerReinforcement called with null: {0},{1},{2},{3},{4}", 
-					new Object[] {player, g, block, type, reinfMat});
+					"Utility createPlayerReinforcement called with null: {0},{1},{2},{3}", 
+					new Object[] {player, g, block, type});
 			return null;
 		}
 

--- a/src/vg/civcraft/mc/citadel/Utility.java
+++ b/src/vg/civcraft/mc/citadel/Utility.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -58,12 +59,27 @@ public class Utility {
      */
     public static PlayerReinforcement createPlayerReinforcement(Player player, Group g, Block block,
             ReinforcementType type, ItemStack reinfMat) {
+		if (player == null || g == null || block == null || type == null || reinfMat == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility createPlayerReinforcement called with null: {0},{1},{2},{3},{4}", 
+					new Object[] {player, g, block, type, reinfMat});
+			return null;
+		}
+
         if (g.isDisciplined()) {
-            player.sendMessage(ChatColor.RED + "This group is disiplined.");
+            player.sendMessage(ChatColor.RED + "This group is disciplined.");
+            if (CitadelConfigManager.shouldLogInternal()) {
+            	Citadel.getInstance().getLogger().log(Level.WARNING,
+            			"Request to create reinforcement for disciplined group " + g.getName());
+            }
             return null;
         }
         if (NonReinforceableType.isNonReinforceable(block.getType())){
             player.sendMessage(ChatColor.RED + "That block cannot be reinforced.");
+            if (CitadelConfigManager.shouldLogInternal()) {
+            	Citadel.getInstance().getLogger().log(Level.WARNING,
+            			"Request to create reinforcement for unreinforceable block " + block.getType());
+            }
             return null;
         }
         // Find necessary itemstacks
@@ -109,6 +125,17 @@ public class Utility {
         if (event.isCancelled()) {
             throw new ReinforcemnetFortificationCancelException();
         }
+		if (CitadelConfigManager.shouldLogReinforcement()) {
+			StringBuffer slb = new StringBuffer();
+			if (player != null) {
+				slb.append("Player ").append(player.getName()).append(" [").append(player.getUniqueId())
+						.append("]");
+			}
+			slb.append("reinforced a ").append(block.getType()).append(" with a ")
+					.append(rein.getMaterial()).append(" reinforcement at ")
+					.append(rein.getLocation());
+			Citadel.Log(slb.toString());
+		}
         // Now eat the materials
         
         // Handle special case with block reinforcements.
@@ -135,8 +162,8 @@ public class Utility {
             requirements -= deduction;
         }
         if (requirements != 0) {
-            Citadel.Log(String.format(
-                "Reinforcement material out of sync %d vs %d", requirements, type.getRequiredAmount()));
+            Citadel.Log(String.format( "Reinforcement material out of sync %d vs %d", 
+					requirements, type.getRequiredAmount()));
         }
         player.updateInventory();
         rm.saveInitialReinforcement(rein);
@@ -155,7 +182,17 @@ public class Utility {
      */
     public static PlayerReinforcement createPlayerReinforcementWithoutMaterialConsumption(Player player, 
             Group g, Block block, ReinforcementType type) {
-        //no error messages towards the player because this might be called a few thousand times 
+		if (g == null || block == null || type == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility createPlayerReinforcementWithoutMaterialConsumption called with null: {0},{1},{2}", 
+					new Object[] {g, block, type});
+			return null;
+		} else if (player == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility createPlayerReinforcementWithoutMaterialConsumption called with player as null");
+		}
+
+    	//no error messages towards the player because this might be called a few thousand times 
         if (g.isDisciplined()) {
             return null;
         }
@@ -183,6 +220,12 @@ public class Utility {
      * @return False if it would not.
      */
     public static boolean wouldPlantDoubleReinforce(final Block block) {
+		if (block == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility wouldPlantDoubleReinforce called with null");
+			return false;
+		}
+    	
         final Material blockMat = block.getType();
         if (isReinforceablePlant(blockMat)
             && rm.getReinforcement(block.getLocation()) != null) {
@@ -204,8 +247,8 @@ public class Utility {
     private static boolean isReinforceablePlant(Material mat) {
         // If this list changes, update wouldPlantDoubleReinforce to account
         // for the new soil types.
-        return mat.equals(Material.MELON_BLOCK)
-            || mat.equals(Material.PUMPKIN);
+        return Material.MELON_BLOCK.equals(mat)
+            || Material.PUMPKIN.equals(mat);
     }
     /**
      * Returns a list of Materials that this plant can go on.
@@ -233,35 +276,35 @@ public class Utility {
     }
     
     private static boolean isSoilPlant(Material mat) {
-        return mat.equals(Material.WHEAT)
-            || mat.equals(Material.MELON_STEM)
-            || mat.equals(Material.PUMPKIN_STEM)
-            || mat.equals(Material.CARROT)
-            || mat.equals(Material.POTATO)
-            || mat.equals(Material.CROPS)
-            || mat.equals(Material.MELON_BLOCK)
-            || mat.equals(Material.PUMPKIN);
+        return Material.WHEAT.equals(mat)
+            || Material.MELON_STEM.equals(mat)
+            || Material.PUMPKIN_STEM.equals(mat)
+            || Material.CARROT.equals(mat)
+            || Material.POTATO.equals(mat)
+            || Material.CROPS.equals(mat)
+            || Material.MELON_BLOCK.equals(mat)
+            || Material.PUMPKIN.equals(mat);
     }
 
     private static boolean isDirtPlant(Material mat) {
-        return mat.equals(Material.SUGAR_CANE_BLOCK)
-            || mat.equals(Material.MELON_BLOCK)
-            || mat.equals(Material.PUMPKIN);
+        return Material.SUGAR_CANE_BLOCK.equals(mat)
+            || Material.MELON_BLOCK.equals(mat)
+            || Material.PUMPKIN.equals(mat);
     }
 
     private static boolean isGrassPlant(Material mat) {
-        return mat.equals(Material.SUGAR_CANE_BLOCK)
-            || mat.equals(Material.MELON_BLOCK)
-            || mat.equals(Material.PUMPKIN);
+        return Material.SUGAR_CANE_BLOCK.equals(mat)
+            || Material.MELON_BLOCK.equals(mat)
+            || Material.PUMPKIN.equals(mat);
     }
 
     private static boolean isSandPlant(Material mat) {
-        return mat.equals(Material.CACTUS)
-            || mat.equals(Material.SUGAR_CANE_BLOCK);
+        return Material.CACTUS.equals(mat)
+            || Material.SUGAR_CANE_BLOCK.equals(mat);
     }
 
     private static boolean isSoulSandPlant(Material mat) {
-        return mat.equals(Material.NETHER_WARTS);
+        return Material.NETHER_WARTS.equals(mat);
     }
 
     public static boolean isPlant(Block plant) {
@@ -292,16 +335,27 @@ public class Utility {
      * @return Returns false if no reinforcement exists and if it was broken.
      */
     public static boolean maybeReinforcementDamaged(Block block) {
+		if (block == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility maybeReinforcementDamaged called with null");
+			return false;
+		}
+
         Reinforcement reinforcement = rm.getReinforcement(block.getLocation());
-        return reinforcement != null && reinforcementDamaged(reinforcement);
+        return reinforcement != null && reinforcementDamaged(null, reinforcement);
     }
     /**
      * Damages the reinforcement.
      * @param The Reinforcement required.
      * @return True if the reinforcement was securable.
      */
-    public static boolean reinforcementDamaged(Reinforcement reinforcement) {
-        int durability = reinforcement.getDurability();
+    public static boolean reinforcementDamaged(Player player, Reinforcement reinforcement) {
+    	if (reinforcement == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility reinforcementDamaged called with null");
+			return false;
+		}
+    	int durability = reinforcement.getDurability();
         int durabilityLoss = 1;
         if (reinforcement instanceof PlayerReinforcement && CitadelConfigManager.isMaturationEnabled()) {
           final int maturationTime = timeUntilMature(reinforcement);
@@ -326,12 +380,50 @@ public class Utility {
               durabilityLoss = durability;
           }
         }
+		int olddurability = durability;
         durability -= durabilityLoss;
         reinforcement.setDurability(durability);
         boolean cancelled = durability > 0;
         if (durability <= 0) {
             cancelled = reinforcementBroken(null, reinforcement);
         } else {
+			/* TODO: Move to ReinforcementEvent listener*/
+			if (CitadelConfigManager.shouldLogBreaks()) {
+				StringBuffer slb = new StringBuffer();
+				if (player != null) {
+					slb.append("Player ").append(player.getName()).append(" [").append(player.getUniqueId())
+							.append("]");
+				} else {
+					slb.append("Something ");
+				}
+				slb.append("damaged a ").append(reinforcement.getMaterial());
+				int strength = 0;
+				if (reinforcement instanceof PlayerReinforcement) {
+					slb.append("reinforcement to ");
+					ReinforcementType type = ReinforcementType.getReinforcementType(
+							((PlayerReinforcement) reinforcement).getStackRepresentation());
+					strength = type.getHitPoints();
+				} else if (reinforcement instanceof NaturalReinforcement) {
+					slb.append("natural reinforcement to ");
+					NaturalReinforcementType type = NaturalReinforcementType.getNaturalReinforcementType(
+							reinforcement.getType());
+					strength = type.getDurability();
+				} else {
+					slb.append("null reinforcement to ");
+				}
+				double nratio = strength > 0 ? (double) durability / (double) strength: 0;
+				double oratio = strength > 0 ? (double) olddurability / (double) strength: 1;
+				if ( nratio <= 0.25 && oratio > 0.25) {
+					slb.append("poor (");
+				} else if ( nratio <= 0.5 && oratio > 0.5) {
+					slb.append("decent (");
+				} else if ( nratio <= 0.75 && oratio > 0.75) {
+					slb.append("well (");
+				} else if ( nratio < 1.0 && oratio == 1.0) {
+					slb.append("excellent (");
+				}
+				slb.append(durability).append(") at ").append(reinforcement.getLocation());
+			}
             if (reinforcement instanceof PlayerReinforcement) {
                 // leave message
             }
@@ -345,7 +437,12 @@ public class Utility {
      * @return Returns 0 if it is mature or the time in minutes until it is mature.
      */
     public static int timeUntilMature(Reinforcement reinforcement) {
-        // Doesn't explicitly save the updated Maturation time into the cache.
+    	if (reinforcement == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility timeUntilMature called with null");
+			return 0;
+		}
+    	// Doesn't explicitly save the updated Maturation time into the cache.
         //  That's the responsibility of the caller.
         if (reinforcement instanceof PlayerReinforcement){
             int maturationTime = reinforcement.getMaturationTime();
@@ -368,7 +465,11 @@ public class Utility {
      * @return Returns 0 if it is mature or the time in minutes until it is mature.
      */
     public static int timeUntilAcidMature(Reinforcement reinforcement) {
-        // Doesn't explicitly save the updated Acid Maturation time into the cache.
+    	if (reinforcement == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility timeUntilAcidMature called with null");
+			return 0;
+		}        // Doesn't explicitly save the updated Acid Maturation time into the cache.
         //  That's the responsibility of the caller.
         if (reinforcement instanceof PlayerReinforcement){
             int maturationTime = reinforcement.getAcidTime();
@@ -388,12 +489,31 @@ public class Utility {
     
     /**
      * 
+     * /ctb mode type break
+     *
      * @param The Player who broke the reinforcement
      * @param The Reinforcement broken.
      * @return Returns true if it is securable.
      * @return Returns false if it is no securable.
      */
     public static boolean reinforcementBroken(Player player, Reinforcement reinforcement) {
+    	if (reinforcement == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility reinforcementBroken called with null reinforcement");
+			return false;
+		}
+    	StringBuffer slb = null;
+		if (CitadelConfigManager.shouldLogBreaks()) {
+			slb = new StringBuffer();
+			if (player != null) {
+				slb.append("Player ").append(player.getName()).append(" [").append(player.getUniqueId())
+						.append("]");
+			} else {
+				slb.append("Something ");
+			}
+			slb.append("broke a ").append(reinforcement.getMaterial()).append(" reinforcement at ")
+					.append(reinforcement.getLocation());
+		}
         Citadel.getReinforcementManager().deleteReinforcement(reinforcement);
         if (reinforcement instanceof PlayerReinforcement) {
             PlayerReinforcement pr = (PlayerReinforcement)reinforcement;
@@ -419,11 +539,22 @@ public class Utility {
                         }
                     }
                 }
-                else
+                else {
                 	dropItemAtLocation(location, new ItemStack(material.getMaterial()
                             , material.getReturnValue()));
+				}
+                if (CitadelConfigManager.shouldLogBreaks()) {
+                    slb.append(" - reinf mat refunded");
+					Citadel.Log(slb.toString());
+                }
+            } else if (CitadelConfigManager.shouldLogBreaks()) { 
+                slb.append(" - reinf mat lost");
+				Citadel.Log(slb.toString());
             }
             return pr.isSecurable();
+        }
+        if (CitadelConfigManager.shouldLogBreaks()) {
+            Citadel.Log(slb.toString());
         }
         return false;  // implicit isSecureable() == false
     }
@@ -442,12 +573,16 @@ public class Utility {
 	 * @author GordonFreemanQ
 	 */
 	public static void dropItemAtLocation(final Location l, final ItemStack is) {
-		
 		// Schedule the item to drop 1 tick later
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Citadel.getInstance(), new Runnable() {
 			@Override
 			public void run() {
-				l.getWorld().dropItem(l.add(0.5, 0.5, 0.5), is).setVelocity(new Vector(0, 0.05, 0));
+				try {
+					l.getWorld().dropItem(l.add(0.5, 0.5, 0.5), is).setVelocity(new Vector(0, 0.05, 0));
+				} catch (Exception e) {
+					Citadel.getInstance().getLogger().log(Level.WARNING,
+								"Utility dropItemAtLocation called but errored: ", e);
+				}
 			}
 		}, 1);
 	}
@@ -461,6 +596,11 @@ public class Utility {
 	 * @author GordonFreemanQ
 	 */
 	public static void dropItemAtLocation(Block b, ItemStack is) {
+    	if (b == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility dropItemAtLocation block called with null");
+			return;
+		}
 		dropItemAtLocation(b.getLocation(), is);
 	}
     
@@ -472,15 +612,20 @@ public class Utility {
      * @return Returns false if the player is not on the group or doesn't have permission.
      */
     public static boolean isAuthorizedPlayerNear(PlayerReinforcement reinforcement, double distance) {
-       
+    	if (reinforcement == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility isAuthorizedPlayerNear called with null");
+			return false;
+		}
         Location reinLocation = reinforcement.getLocation();
         double min_x = reinLocation.getX() - distance;
         double min_z = reinLocation.getZ() - distance;
         double max_x = reinLocation.getX() + distance;
         double max_z = reinLocation.getZ() + distance;
         List<Player> onlinePlayers = new ArrayList<Player>();
-        for (Player p: Bukkit.getOnlinePlayers())
+        for (Player p: Bukkit.getOnlinePlayers()) {
             onlinePlayers.add(p);
+        }
         boolean result = false;
         try {
             for (Player player : onlinePlayers) {
@@ -518,16 +663,27 @@ public class Utility {
      * @return Returns a natural Reinforcement for the block or null if it isn't meant to have one.
      */
     public static NaturalReinforcement createNaturalReinforcement(Block block, Player player) {
+    	if (block == null || player == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility createNaturalReinforcement called with null");
+			return null;
+		}
         Material material = block.getType();
         NaturalReinforcementType nType = NaturalReinforcementType.
                 getNaturalReinforcementType(material);
-        if (nType == null)
+        if (nType == null) {
             return null;
+        }
         int breakCount = nType.getDurability();
         NaturalReinforcement nr = new NaturalReinforcement(block, breakCount);
         ReinforcementCreationEvent event = new ReinforcementCreationEvent(nr, block, player);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
+            if (CitadelConfigManager.shouldLogInternal()) {
+            	Citadel.getInstance().getLogger().log(Level.INFO,
+            			"createNaturalReinforcement for " + block.getType() + " cancelled");
+            }
+
             return null;
         }
         Citadel.getReinforcementManager().saveInitialReinforcement(nr);
@@ -541,19 +697,25 @@ public class Utility {
      * @return Itemstack form of the reinforcement on a block
      */
     public static ItemStack createDroppedReinforcementBlock(Block block, PlayerReinforcement rein){
+    	if (block == null || rein == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility createDroppedReinforcementBlock called with null");
+			return null;
+		}
         ItemStack reinBlock = new ItemStack(block.getType(), 1);
         ItemMeta lore = reinBlock.getItemMeta();
         List<String> info = new ArrayList<String>();
         String reinMat = rein.getMaterial().name();
-        String amount = "" + rein.getStackRepresentation().getAmount();
-        String dur = "" + ReinforcementType.getReinforcementType(rein.getStackRepresentation()).getHitPoints();
+        String amount = Integer.toString(rein.getStackRepresentation().getAmount());
+        String dur = Integer.toString(ReinforcementType.getReinforcementType(rein.getStackRepresentation()).getHitPoints());
         String group = rein.getGroup().getName();
         info.add(reinMat);
         info.add(amount);
         info.add(dur);
         info.add(group);
-        if (rein.getStackRepresentation().hasItemMeta())
+        if (rein.getStackRepresentation().hasItemMeta()) {
             info.addAll(rein.getStackRepresentation().getItemMeta().getLore());
+        }
         lore.setLore(info);
         reinBlock.setItemMeta(lore);
         return reinBlock;
@@ -568,47 +730,67 @@ public class Utility {
      * @return The PlayerReiforcement associated with this block
      */
     public static PlayerReinforcement isDroppedReinforcementBlock(Player p, ItemStack stack, Location loc){
+    	if (stack == null || loc == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility isDroppedReinforcementBlock called with null");
+			return null;
+		}
         ItemMeta meta = stack.getItemMeta();
         List<String> lore = meta.getLore();
         try{
-        if (!meta.hasLore())
-            return null;
-        Iterator<String> value = lore.iterator();
-        if (!value.hasNext())
-            return null;
-        Material mat = Material.valueOf(value.next());
-        if (!value.hasNext())
-            return null;
-        int amount = Integer.parseInt(value.next());
-        if (!value.hasNext())
-            return null;
-        int dur = Integer.parseInt(value.next());
-        if (!value.hasNext())
-            return null;
-        String group = value.next();
-        List<String> itemStackInfo = new ArrayList<String>();
-        while(value.hasNext())
-            itemStackInfo.add(value.next());
-        ItemStack newStack = new ItemStack(mat, amount);
-        meta.setLore(itemStackInfo);
-        newStack.setItemMeta(meta);
-        ReinforcementType reinType = ReinforcementType.getReinforcementType(newStack);
-        if (reinType == null)
-            return null;
-        Group g = GroupManager.getSpecialCircumstanceGroup(group);
-        PlayerReinforcement rein = new PlayerReinforcement(loc, dur, 
-                getIntFormofMaturation(System.currentTimeMillis(),reinType.getItemStack()),
-                getIntFormofAcidMaturation(System.currentTimeMillis(),reinType.getItemStack()),
-                g, reinType.getItemStack());
-        ReinforcementCreationEvent event = 
-                new ReinforcementCreationEvent(rein, loc.getBlock(), p);
-        Bukkit.getPluginManager().callEvent(event);
-        if (event.isCancelled())
-            return null;
-        return rein;
+	        if (!meta.hasLore()) {
+	            return null;
+	        }
+	        Iterator<String> value = lore.iterator();
+	        if (!value.hasNext()) {
+	            return null;
+	        }
+	        Material mat = Material.valueOf(value.next());
+	        if (!value.hasNext()) {
+	            return null;
+	        }
+	        int amount = Integer.parseInt(value.next());
+	        if (!value.hasNext()) {
+	            return null;
+	        }
+	        int dur = Integer.parseInt(value.next());
+	        if (!value.hasNext()) {
+	            return null;
+	        }
+	        String group = value.next();
+	        List<String> itemStackInfo = new ArrayList<String>();
+	        while(value.hasNext()) {
+	            itemStackInfo.add(value.next());
+	        }
+	        ItemStack newStack = new ItemStack(mat, amount);
+	        meta.setLore(itemStackInfo);
+	        newStack.setItemMeta(meta);
+	        ReinforcementType reinType = ReinforcementType.getReinforcementType(newStack);
+	        if (reinType == null) {
+	            return null;
+	        }
+	        Group g = GroupManager.getSpecialCircumstanceGroup(group);
+	        PlayerReinforcement rein = new PlayerReinforcement(loc, dur, 
+	                getIntFormofMaturation(System.currentTimeMillis(),reinType.getItemStack()),
+	                getIntFormofAcidMaturation(System.currentTimeMillis(),reinType.getItemStack()),
+	                g, reinType.getItemStack());
+	        ReinforcementCreationEvent event = 
+	                new ReinforcementCreationEvent(rein, loc.getBlock(), p);
+	        Bukkit.getPluginManager().callEvent(event);
+	        if (event.isCancelled()) {
+	            if (CitadelConfigManager.shouldLogInternal()) {
+	            	Citadel.getInstance().getLogger().log(Level.INFO,
+	            			"Dropped reinforcement creation event for " + rein.getType() + " cancelled");
+	            }
+	            return null;
+	        }
+	        return rein;
         } catch (IllegalArgumentException iae){
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility isDroppedReinforcementBlock failed", iae);        	
         } catch(Exception ex){
-            ex.printStackTrace();
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility isDroppedReinforcementBlock failed", ex);
         }
         return null;
     }
@@ -620,14 +802,19 @@ public class Utility {
      * @return False if there is not a reinforcement.
      */
     public static boolean explodeReinforcement(Block block) {
-        Reinforcement reinforcement = rm.getReinforcement(block);
+    	if (block == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility explodeReinforcement called with null");
+			return false;
+		}
+    	Reinforcement reinforcement = rm.getReinforcement(block);
         if (reinforcement == null) {
             reinforcement = createNaturalReinforcement(block, null);
         }
         if (reinforcement == null) {
             return false;
         }
-        return reinforcementDamaged(reinforcement);
+        return reinforcementDamaged(null, reinforcement);
     }
     
     /**
@@ -641,10 +828,19 @@ public class Utility {
      * @return
      */
     public static MultiBlockReinforcement createMultiBlockReinforcement(List<Location> locs, Group g, int dur, int mature, int acid){
+    	if (locs == null || g == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility createMultiBlockReinforcement called with null");
+			return null;
+		}
         MultiBlockReinforcement rein = new MultiBlockReinforcement(locs, g, dur, mature, acid, -1);
         ReinforcementCreationEvent event = new ReinforcementCreationEvent(rein, rein.getLocation().getBlock(), null);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
+            if (CitadelConfigManager.shouldLogInternal()) {
+            	Citadel.getInstance().getLogger().log(Level.INFO,
+            			"multiblock reinforcement creation event for " + rein.getType() + " cancelled");
+            }
             return null;
         }
         rm.saveInitialReinforcement(rein);
@@ -652,9 +848,14 @@ public class Utility {
     }
     
     public static Block getAttachedChest(Block block) {
+    	if (block == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility getAttachedChest called with null");
+			return null;
+		}
         Material mat = block.getType();
-        if (mat == Material.CHEST || mat == Material.TRAPPED_CHEST) {
-            for (BlockFace face : new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST}) {
+        if (Material.CHEST.equals(mat) || Material.TRAPPED_CHEST.equals(mat)) {
+            for (BlockFace face : cardinals) {
                 Block b = block.getRelative(face);
                 if (b.getType() == mat) {
                     return b;
@@ -663,6 +864,8 @@ public class Utility {
         }
         return null;
     }
+    
+    private static BlockFace[] cardinals = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST}; 
     
     public static List<Material> doorTypes = new ArrayList<Material>(Arrays.asList(
             Material.WOODEN_DOOR, Material.IRON_DOOR_BLOCK,
@@ -675,14 +878,21 @@ public class Utility {
      * @return Returns the block we want.
      */
     public static Block getRealBlock(Block block){
+    	if (block == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility getRealBlock called with null");
+			return null;
+		}    	
         Block b = block;
         switch (block.getType()){
         case CHEST:
         case TRAPPED_CHEST:
-            if (!rm.isReinforced(block))
+            if (!rm.isReinforced(block)) {
                 b = getAttachedChest(block);
-            if (b == null)
+            }
+            if (b == null) {
                 b = block;
+            }
             break;
         case WOODEN_DOOR:
         case IRON_DOOR_BLOCK:
@@ -692,20 +902,27 @@ public class Utility {
         case JUNGLE_DOOR:
         case SPRUCE_DOOR:
         case WOOD_DOOR:
-            if (!doorTypes.contains(block.getRelative(BlockFace.UP).getType()))
+            if (!doorTypes.contains(block.getRelative(BlockFace.UP).getType())) {
                 b = block.getRelative(BlockFace.DOWN);
+            }
             break;
         case BED_BLOCK:
-            if (((Bed) block.getState().getData()).isHeadOfBed())
+            if (((Bed) block.getState().getData()).isHeadOfBed()) {
                 b = block.getRelative(((Bed) block.getState().getData()).getFacing().getOppositeFace());
+            }
             break;
         default:
-            return block;
+            b = block;
         }
         return b;
     }
     
     private static int getIntFormofMaturation(long creation, ItemStack stack){
+    	if (stack == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility getIntFormofMaturation called with null");
+			return 0;
+		}
         int maturation = (int)(creation / 60000) + 
                 ReinforcementType.
                 getReinforcementType(stack)
@@ -714,7 +931,12 @@ public class Utility {
     }
     
     private static int getIntFormofAcidMaturation(long creation, ItemStack stack) {
-        int maturation = (int)(creation / 60000) + 
+    	if (stack == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility getIntFormofAcidMaturation called with null");
+			return 0;
+		}
+    	int maturation = (int)(creation / 60000) + 
                 ReinforcementType.
                 getReinforcementType(stack)
                 .getAcidTime();
@@ -722,6 +944,11 @@ public class Utility {
     }
     
     public static Block findPlantSoil(Block block){
+    	if (block == null) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"Utility findPlantSoil called with null");
+			return null;
+		}    	
         final Set<Material> soilTypes = getPlantSoilTypes(block.getType());
         if(soilTypes.size() <= 0){
             return null;

--- a/src/vg/civcraft/mc/citadel/command/CommandHandler.java
+++ b/src/vg/civcraft/mc/citadel/command/CommandHandler.java
@@ -3,10 +3,13 @@ package vg.civcraft.mc.citadel.command;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
+import vg.civcraft.mc.citadel.Citadel;
+import vg.civcraft.mc.citadel.CitadelConfigManager;
 import vg.civcraft.mc.citadel.command.commands.Acid;
 import vg.civcraft.mc.citadel.command.commands.AreaReinforce;
 import vg.civcraft.mc.citadel.command.commands.Bypass;
@@ -16,6 +19,7 @@ import vg.civcraft.mc.citadel.command.commands.Insecure;
 import vg.civcraft.mc.citadel.command.commands.Materials;
 import vg.civcraft.mc.citadel.command.commands.Off;
 import vg.civcraft.mc.citadel.command.commands.Reinforce;
+import vg.civcraft.mc.citadel.command.commands.SetLogging;
 import vg.civcraft.mc.citadel.command.commands.Stats;
 import vg.civcraft.mc.citadel.command.commands.UpdateReinforcements;
 import vg.civcraft.mc.civmodcore.command.Command;
@@ -37,6 +41,7 @@ public class CommandHandler {
 		addCommands(new Stats("Stats"));
 		addCommands(new UpdateReinforcements("UpdateReinforcements"));
 		addCommands(new AreaReinforce("AreaReinforce"));
+		addCommands(new SetLogging("SetLogging"));
 	}
 	
 	private void addCommands(Command command){
@@ -57,6 +62,7 @@ public class CommandHandler {
 				helpPlayer(command, sender);
 				return true;
 			}
+			
 			command.execute(sender, args);
 		}
 		return true;

--- a/src/vg/civcraft/mc/citadel/command/commands/AreaReinforce.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/AreaReinforce.java
@@ -18,10 +18,9 @@ import vg.civcraft.mc.citadel.Utility;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.NameAPI;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.group.Group;
 
-public class AreaReinforce extends PlayerCommand {
+public class AreaReinforce extends PlayerCommandMiddle {
 	private ReinforcementManager rm = Citadel.getReinforcementManager();
 	private GroupManager gm = NameAPI.getGroupManager();
 
@@ -44,22 +43,20 @@ public class AreaReinforce extends PlayerCommand {
 		if (!p.isOp() && !p.hasPermission("citadel.admin")) {
 			// This should never actually happen thanks to the plugin.yml, but
 			// we just want to be sure
-			p.sendMessage(ChatColor.RED + "Nice try");
+			sendAndLog(p, ChatColor.RED, "Nice try");
 			return true;
 		}
 		ReinforcementType rt = ReinforcementType.getReinforcementType(p
 				.getItemInHand());
 		if (rt == null) {
-			p.sendMessage(ChatColor.RED
-					+ "The item you are holding is not a possible reinforcement");
+			sendAndLog(p, ChatColor.RED, "The item you are holding is not a possible reinforcement");
 			return true;
 		}
 		String groupName = null;
 		if (args.length == 6) {
 			groupName = gm.getDefaultGroup(uuid);
 			if (groupName == null) {
-				p.sendMessage(ChatColor.RED
-						+ "You need to set a default group \n Use /nlsdg to do so");
+				sendAndLog(p, ChatColor.RED, "You need to set a default group \n Use /nlsdg to do so");
 				return true;
 			}
 		} else {
@@ -67,7 +64,7 @@ public class AreaReinforce extends PlayerCommand {
 		}
 		Group g = gm.getGroup(groupName);
 		if (g == null) {
-			p.sendMessage(ChatColor.RED + "That group does not exist.");
+			sendAndLog(p, ChatColor.RED, "That group does not exist.");
 			return true;
 		}
 		// no additional group permission check here because the player is
@@ -88,8 +85,7 @@ public class AreaReinforce extends PlayerCommand {
 			yMax = Math.max(y1, y2);
 			zMax = Math.max(z1, z2);
 		} catch (NumberFormatException e) {
-			p.sendMessage(ChatColor.RED
-					+ "One of the arguments you provided was not a number");
+			sendAndLog(p, ChatColor.RED, "One of the arguments you provided was not a number");
 			return false;
 		}
 		for (int x = xMin; x <= xMax; x++) {
@@ -105,7 +101,7 @@ public class AreaReinforce extends PlayerCommand {
 			}
 		}
 
-		p.sendMessage("Successfully created reinforcements");
+		sendAndLog(p, ChatColor.GREEN, "Successfully created reinforcements");
 		return true;
 	}
 	

--- a/src/vg/civcraft/mc/citadel/command/commands/Bypass.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Bypass.java
@@ -7,12 +7,11 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementManager;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class Bypass extends PlayerCommand{
+public class Bypass extends PlayerCommandMiddle{
 	private ReinforcementManager rm = Citadel.getReinforcementManager();
 
 	public Bypass(String name) {
@@ -32,10 +31,11 @@ public class Bypass extends PlayerCommand{
 		Player p = (Player) sender;
 		PlayerState state = PlayerState.get(p);
 		if (state.toggleBypassMode()){
-			p.sendMessage(ChatColor.GREEN + "Bypass mode has been enabled.");
+			sendAndLog(p, ChatColor.GREEN, "Bypass mode has been enabled.");
 		}
-		else 
-			p.sendMessage(ChatColor.GREEN + "Bypass mode has been disabled.");
+		else  {
+			sendAndLog(p, ChatColor.GREEN, "Bypass mode has been disabled.");
+		}
 		return true;
 	}
 
@@ -43,5 +43,4 @@ public class Bypass extends PlayerCommand{
 	public List<String> tabComplete(CommandSender sender, String[] args) {
 		return new ArrayList<String>();
 	}
-
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Fortification.java
@@ -3,7 +3,6 @@ package vg.civcraft.mc.citadel.command.commands;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
@@ -18,13 +17,12 @@ import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
-public class Fortification extends PlayerCommand{
+public class Fortification extends PlayerCommandMiddle{
 	private ReinforcementManager rm = Citadel.getReinforcementManager();
 	private GroupManager gm = NameAPI.getGroupManager();
 
@@ -48,7 +46,7 @@ public class Fortification extends PlayerCommand{
 		if(args.length == 0){
 			groupName = gm.getDefaultGroup(uuid);
 			if(groupName == null){
-				p.sendMessage(ChatColor.RED + "You need to set a default group \n Use /nlsdg to do so");
+				sendAndLog(p, ChatColor.RED, "You need to set a default group \n Use /nlsdg to do so");
 				return true;
 			}
 		}
@@ -57,18 +55,18 @@ public class Fortification extends PlayerCommand{
 		}
 		Group g = gm.getGroup(groupName);	
 		if (g == null){
-			p.sendMessage(ChatColor.RED + "That group does not exist.");
+			sendAndLog(p, ChatColor.RED, "That group does not exist.");
 			return true;
 		}
 		
 		PlayerType type = g.getPlayerType(uuid);
 		if (!p.hasPermission("citadel.admin") && !p.isOp() && type == null){
-			p.sendMessage(ChatColor.RED + "You are not on this group.");
+			sendAndLog(p, ChatColor.RED, "You are not on this group.");
 			return true;
 		}
 		GroupPermission gPerm = gm.getPermissionforGroup(g);
 		if (!p.hasPermission("citadel.admin") && !p.isOp() && !gPerm.isAccessible(type, PermissionType.BLOCKS)){
-			p.sendMessage(ChatColor.RED + "You do not have permission to "
+			sendAndLog(p, ChatColor.RED, "You do not have permission to "
 					+ "place a reinforcement on this group.");
 			return true;
 		}
@@ -76,19 +74,19 @@ public class Fortification extends PlayerCommand{
 		PlayerState state = PlayerState.get(p);
 		ReinforcementType reinType = ReinforcementType.getReinforcementType(stack);
 		if (state.getMode() == ReinforcementMode.REINFORCEMENT_FORTIFICATION){
-			p.sendMessage(ChatColor.GREEN + state.getMode().name() + " has been disabled");
+			sendAndLog(p, ChatColor.GREEN, state.getMode().name() + " has been disabled");
 			state.reset();
 		}
 		else{
 			if (stack.getType() == Material.AIR){
-				p.sendMessage(ChatColor.RED + "You need to be holding an ItemStack.");
+				sendAndLog(p, ChatColor.RED, "You need to be holding an ItemStack.");
 				return true;
 			}
 			else if (reinType == null){
-				p.sendMessage(ChatColor.RED + "That is not a ReinforcementType.");
+				sendAndLog(p, ChatColor.RED, "That is not a ReinforcementType.");
 				return true;
 			}
-			p.sendMessage(ChatColor.GREEN + "Your mode has been set to " + 
+			sendAndLog(p, ChatColor.GREEN, "Your mode has been set to " + 
 					ReinforcementMode.REINFORCEMENT_FORTIFICATION.name() + ".");
 			state.setMode(ReinforcementMode.REINFORCEMENT_FORTIFICATION);
 			state.setFortificationItemStack(reinType.getItemStack());
@@ -110,5 +108,4 @@ public class Fortification extends PlayerCommand{
 			return new ArrayList<String>();
 		}
 	}
-
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Information.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Information.java
@@ -6,12 +6,11 @@ import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class Information extends PlayerCommand{
+public class Information extends PlayerCommandMiddle{
 
 	public Information(String name) {
 		super(name);
@@ -30,11 +29,11 @@ public class Information extends PlayerCommand{
 		Player p = (Player) sender;
 		PlayerState state = PlayerState.get(p);
 		if (state.getMode() == ReinforcementMode.REINFORCEMENT_INFORMATION){
-			p.sendMessage(ChatColor.GREEN + state.getMode().name() + " has been disabled");
+			sendAndLog(p, ChatColor.GREEN, state.getMode().name() + " has been disabled");
 			state.reset();
 		}
 		else{
-			p.sendMessage(ChatColor.GREEN + "Reinforcement mode changed to "
+			sendAndLog(p, ChatColor.GREEN, "Reinforcement mode changed to "
 					+ ReinforcementMode.REINFORCEMENT_INFORMATION.name() + ".");
 			state.setMode(ReinforcementMode.REINFORCEMENT_INFORMATION);
 		}
@@ -45,5 +44,4 @@ public class Information extends PlayerCommand{
 	public List<String> tabComplete(CommandSender sender, String[] args) {
 		return new ArrayList<String>();
 	}
-
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/Insecure.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Insecure.java
@@ -6,12 +6,11 @@ import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class Insecure extends PlayerCommand{
+public class Insecure extends PlayerCommandMiddle{
 
 	public Insecure(String name) {
 		super(name);
@@ -30,11 +29,11 @@ public class Insecure extends PlayerCommand{
 		Player p = (Player) sender;
 		PlayerState state = PlayerState.get(p);
 		if (state.getMode() == ReinforcementMode.INSECURE){
-			p.sendMessage(ChatColor.GREEN + state.getMode().name() + " has been disabled");
+			sendAndLog(p, ChatColor.GREEN, state.getMode().name() + " has been disabled");
 			state.reset();
 		}
 		else{
-			p.sendMessage(ChatColor.GREEN + "Reinforcement mode changed to "
+			sendAndLog(p, ChatColor.GREEN, "Reinforcement mode changed to "
 					+ ReinforcementMode.INSECURE.name() + ".");
 			state.setMode(ReinforcementMode.INSECURE);
 		}

--- a/src/vg/civcraft/mc/citadel/command/commands/Materials.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Materials.java
@@ -8,9 +8,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 
-public class Materials extends PlayerCommand{
+public class Materials extends PlayerCommandMiddle{
 
 	public Materials(String name) {
 		super(name);
@@ -32,9 +31,10 @@ public class Materials extends PlayerCommand{
 		for (ReinforcementType type: types){
 			t += type.getMaterial().name() + ":\n   ";
 			t += "Amount: " + type.getRequiredAmount() + ".\n   ";
-			t += "Durability: " + type.getHitPoints() + ".\n   ";
+			t += "Strength: " + type.getHitPoints() + ".\n   ";
 			t += "Material: " + type.getMaterial() + ".\n   ";
 			t += "Maturation: " + type.getMaturationTime() + ".\n   ";
+			t += "Acid Maturation: " + type.getAcidTime() + ".\n   ";
 			if (type.getItemStack().getItemMeta().hasLore()){
 				t += "Lore: ";
 				for (String x: type.getItemStack().getItemMeta().getLore())

--- a/src/vg/civcraft/mc/citadel/command/commands/Off.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Off.java
@@ -5,12 +5,11 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.citadel.PlayerState;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class Off extends PlayerCommand{
+public class Off extends PlayerCommandMiddle{
 
 	public Off(String name) {
 		super(name);
@@ -29,9 +28,10 @@ public class Off extends PlayerCommand{
 		Player p = (Player) sender;
 		PlayerState state = PlayerState.get(p);
 		state.reset();
-		if (state.isBypassMode())
+		if (state.isBypassMode()) {
 			state.toggleBypassMode();
-		p.sendMessage(ChatColor.GREEN + "Reinforcement mode has been set to Normal.");
+		}
+		sendAndLog(p, ChatColor.GREEN, "Reinforcement mode has been set to Normal.");
 		return true;
 	}
 

--- a/src/vg/civcraft/mc/citadel/command/commands/PlayerCommandMiddle.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/PlayerCommandMiddle.java
@@ -1,0 +1,25 @@
+package vg.civcraft.mc.citadel.command.commands;
+
+import java.util.logging.Level;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import vg.civcraft.mc.citadel.Citadel;
+import vg.civcraft.mc.citadel.CitadelConfigManager;
+import vg.civcraft.mc.civmodcore.command.PlayerCommand;
+
+public abstract class PlayerCommandMiddle extends PlayerCommand {
+
+	public PlayerCommandMiddle(String name) {
+		super(name);
+	}
+
+	protected void sendAndLog(CommandSender receiver, ChatColor color, String message) {
+		receiver.sendMessage(color + message);
+		if (CitadelConfigManager.shouldLogPlayerCommands()) {
+			Citadel.getInstance().getLogger().log(Level.INFO, "Sent {0} reply {1}", new Object[]{receiver.getName(), message});
+		}
+	}
+}

--- a/src/vg/civcraft/mc/citadel/command/commands/Reinforce.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Reinforce.java
@@ -3,23 +3,20 @@ package vg.civcraft.mc.citadel.command.commands;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-
 import vg.civcraft.mc.citadel.PlayerState;
 import vg.civcraft.mc.citadel.ReinforcementMode;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
-public class Reinforce extends PlayerCommand {
+public class Reinforce extends PlayerCommandMiddle {
 
 	private GroupManager gm = NameAPI.getGroupManager();
 	
@@ -43,7 +40,7 @@ public class Reinforce extends PlayerCommand {
 		if(args.length == 0){
 			groupName = gm.getDefaultGroup(uuid);
 			if(groupName == null){
-				p.sendMessage(ChatColor.RED + "You need to set a default group \n Use /nlsdg to do so");
+				sendAndLog(p, ChatColor.RED, "You need to set a default group \n Use /nlsdg to do so");
 				return true;
 			}
 		}
@@ -52,27 +49,27 @@ public class Reinforce extends PlayerCommand {
 		}
 		Group g = gm.getGroup(groupName);
 		if (g == null){
-			p.sendMessage(ChatColor.RED + "That group does not exist.");
+			sendAndLog(p, ChatColor.RED, "That group does not exist.");
 			return true;
 		}
 		PlayerType type = g.getPlayerType(uuid);
 		if (!p.hasPermission("citadel.admin") && !p.isOp() && type == null){
-			p.sendMessage(ChatColor.RED + "You are not on this group.");
+			sendAndLog(p, ChatColor.RED, "You are not on this group.");
 			return true;
 		}
 		GroupPermission gPerm = gm.getPermissionforGroup(g);
 		if (!p.hasPermission("citadel.admin") && !p.isOp() && !gPerm.isAccessible(type, PermissionType.BLOCKS)){
-			p.sendMessage(ChatColor.RED + "You do not have permission to "
+			sendAndLog(p, ChatColor.RED, "You do not have permission to "
 					+ "place a reinforcement on this group.");
 			return true;
 		}
 		PlayerState state = PlayerState.get(p);
 		if (state.getMode() == ReinforcementMode.REINFORCEMENT){
-			p.sendMessage(ChatColor.GREEN + state.getMode().name() + " has been disabled");
+			sendAndLog(p, ChatColor.GREEN, state.getMode().name() + " has been disabled");
 			state.reset();
 		}
 		else{
-			p.sendMessage(ChatColor.GREEN + "Your mode has been set to " + 
+			sendAndLog(p, ChatColor.GREEN, "Your mode has been set to " + 
 					ReinforcementMode.REINFORCEMENT.name() + ".");
 			state.setMode(ReinforcementMode.REINFORCEMENT);
 			state.setGroup(g);
@@ -93,5 +90,4 @@ public class Reinforce extends PlayerCommand {
 			return new ArrayList<String>();
 		}
 	}
-
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/SetLogging.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/SetLogging.java
@@ -1,0 +1,117 @@
+package vg.civcraft.mc.citadel.command.commands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+
+import vg.civcraft.mc.citadel.Citadel;
+import vg.civcraft.mc.citadel.CitadelConfigManager;
+
+public class SetLogging extends PlayerCommandMiddle {
+
+	public SetLogging(String name) {
+		super(name);
+		setIdentifier("ctsl");
+		setDescription("Allows admins to toggle special logging types live or show current status");
+		setUsage("/ctsl [internal|playercommands|breaks|reinforcements [on|off]]");
+		setArguments(0, 2);
+	}
+
+	@Override
+	public boolean execute(CommandSender sender, String[] args) {
+		if (args.length > 0 && !cmds.contains(args[0])) {
+			return false;
+		}
+		
+		if (args.length >= 1 && !flgs.contains(args[1])) {
+			return false;
+		}
+		
+		if (!(sender instanceof ConsoleCommandSender) && !sender.isOp() && !sender.hasPermission("citadel.admin")) {
+			// This should never actually happen thanks to the plugin.yml, but
+			// we just want to be sure
+			sendAndLog(sender, ChatColor.RED, "Nice try");
+			return true;
+		}
+		
+		// validated, so lets just do it.
+		if (args.length == 0) {
+			StringBuilder sb = new StringBuilder("Current deep logging set to: \n");
+			sb.append("   Internal: ").append(CitadelConfigManager.shouldLogInternal()).append("\n");
+			sb.append("   Player Command Responses: ").append(CitadelConfigManager.shouldLogPlayerCommands()).append("\n");
+			sb.append("   Breaks: ").append(CitadelConfigManager.shouldLogBreaks()).append("\n");
+			sb.append("   Reinforcements: ").append(CitadelConfigManager.shouldLogReinforcement()).append("\n");
+			
+			sendAndLog(sender, ChatColor.GREEN, sb.toString());
+		}
+		
+		String flag = null;
+		boolean newval = false;
+		if (args.length >= 1) {
+			if ("internal".equalsIgnoreCase(args[0])) {
+				flag = "internal_logging";
+				newval = CitadelConfigManager.shouldLogInternal();				
+			} else if ("playercommands".equalsIgnoreCase(args[0])) {
+				flag = "command_logging";
+				newval = CitadelConfigManager.shouldLogPlayerCommands();				
+			} else if ("breaks".equalsIgnoreCase(args[0])) {
+				flag = "break_logging";
+				newval = CitadelConfigManager.shouldLogBreaks();
+			} else if ("reinforcements".equalsIgnoreCase(args[0])) {
+				flag = "reinf_logging";
+				newval = CitadelConfigManager.shouldLogReinforcement();				
+			}
+		}
+		
+		if (args.length < 2) {
+			newval = !newval; // invert current.
+		} else {
+			// If can't figure it out, leave current.
+			newval = "on".equalsIgnoreCase(args[1])? true : "off".equalsIgnoreCase(args[1]) ? false : newval;
+		}
+		
+		if (flag != null) {
+			Citadel.getInstance().getConfig().set(flag, newval);
+			sendAndLog(sender, ChatColor.GREEN, "Flag " + newval + " is " + (newval ? "on" : "off"));
+			return true;
+		} else {
+			sendAndLog(sender, ChatColor.RED, "Unknown setting!");
+			return false;
+		}
+	}
+
+	private static List<String> cmds = Arrays.asList("internal","playercommands", "breaks", "reinforcements");
+	private static List<String> flgs = Arrays.asList("on", "off");
+	@Override
+	public List<String> tabComplete(CommandSender arg0, String[] arg1) {
+		if (arg1.length == 0) {
+			return cmds;
+		} else if (arg1.length == 1) {
+			ArrayList<String> lst = new ArrayList<String>();
+			for (String cmd : cmds) {
+				if (cmd.toLowerCase().equals(arg1[0])) {
+					return flgs;
+				} else if (cmd.contains(arg1[0].toLowerCase())) {
+					lst.add(cmd);
+				}
+			}
+			return lst;
+		} else if (arg1.length == 2) {
+			ArrayList<String> lst = new ArrayList<String>();
+			for (String flg : flgs) {
+				if (flg.toLowerCase().equals(arg1[1])) {
+					return flgs;
+				} else if (flg.contains(arg1[1].toLowerCase())) {
+					lst.add(flg);
+				}
+			}
+			return lst;
+		}
+		return null;
+	}
+
+}

--- a/src/vg/civcraft/mc/citadel/command/commands/Stats.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/Stats.java
@@ -3,7 +3,6 @@ package vg.civcraft.mc.citadel.command.commands;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -12,11 +11,10 @@ import org.bukkit.entity.Player;
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.NameAPI;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.command.TabCompleters.GroupTabCompleter;
 import vg.civcraft.mc.namelayer.group.Group;
 
-public class Stats extends PlayerCommand{
+public class Stats extends PlayerCommandMiddle{
 
 	private List<Group> run = new ArrayList<Group>();
 	private GroupManager gm = NameAPI.getGroupManager();
@@ -37,7 +35,7 @@ public class Stats extends PlayerCommand{
 		}
 		Player p = (Player) sender;
 		if (!(p.isOp() || p.hasPermission("citadel.admin"))){
-			p.sendMessage(ChatColor.RED + "You do not have permission for this command.");
+			sendAndLog(p, ChatColor.RED, "You do not have permission for this command.");
 			return true;
 		}
 		if (args.length == 0){
@@ -47,17 +45,17 @@ public class Stats extends PlayerCommand{
 		Group g = gm.getGroup(args[0]);
 		
 		if (g == null){
-			p.sendMessage(ChatColor.RED + "This group does not exist.");
+			sendAndLog(p, ChatColor.RED, "This group does not exist.");
 			return true;
 		}
 		UUID uuid = NameAPI.getUUID(p.getName());
 		if (!g.isMember(uuid) && !(p.isOp() || p.hasPermission("citadel.admin"))){
-			p.sendMessage(ChatColor.RED + "You are not on this group.");
+			sendAndLog(p, ChatColor.RED, "You are not on this group.");
 			return true;
 		}
 		synchronized(run){
 			if (run.contains(g)){
-				p.sendMessage(ChatColor.RED + "That group is already being searched for.");
+				sendAndLog(p, ChatColor.RED, "That group is already being searched for.");
 				return true;
 			}
 			run.add(g);
@@ -71,11 +69,13 @@ public class Stats extends PlayerCommand{
 		if (!(sender instanceof Player))
 			return new ArrayList<String>();
 
-		if (args.length == 0)
+		if (args.length == 0) {
 			return GroupTabCompleter.complete(null, null, (Player)sender);
-		else if (args.length == 1)
+		} else if (args.length == 1) {
 			return GroupTabCompleter.complete(args[0], null, (Player)sender);
-		else return  new ArrayList<String>();
+		} else {
+			return new ArrayList<String>();
+		}
 
 	}
 
@@ -91,15 +91,19 @@ public class Stats extends PlayerCommand{
 		
 		@Override
 		public void run() {
-			String message = ChatColor.GREEN + "The amount of reinforcements on this group are: ";
+			if (g == null || p == null) {
+				return;
+			}
+			String message = "The amount of reinforcements on this group are: ";
 			int count = Citadel.getCitadelDatabase().getReinCountForGroup(g.getName());
-			message += count;
+			message += Integer.toString(count);
 			synchronized(run){
 				run.remove(g);
 			}
-			if (p != null && !p.isOnline()) // meh be safe
+			if (p != null && !p.isOnline()) {// meh be safe
 				return;
-			p.sendMessage(message);
+			}
+			sendAndLog(p, ChatColor.GREEN, message);
 		}
 		
 	}
@@ -113,13 +117,12 @@ public class Stats extends PlayerCommand{
 		
 		@Override
 		public void run() {
-			String message = ChatColor.GREEN + "The amount of reinforcements on the server are: ";
+			String message = "The amount of reinforcements on the server are: ";
 			int count = Citadel.getCitadelDatabase().getReinCountForAllGroups();
 			message += count;
 			if (p != null && !p.isOnline()) // meh be safe
 				return;
-			p.sendMessage(message);
+			sendAndLog(p, ChatColor.GREEN, message);
 		}
 	}
-
 }

--- a/src/vg/civcraft/mc/citadel/command/commands/UpdateReinforcements.java
+++ b/src/vg/civcraft/mc/citadel/command/commands/UpdateReinforcements.java
@@ -15,12 +15,11 @@ import vg.civcraft.mc.citadel.ReinforcementManager;
 import vg.civcraft.mc.citadel.reinforcement.MultiBlockReinforcement;
 import vg.civcraft.mc.citadel.reinforcement.PlayerReinforcement;
 import vg.civcraft.mc.citadel.reinforcement.Reinforcement;
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 import vg.civcraft.mc.namelayer.GroupManager;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.group.Group;
 
-public class UpdateReinforcements extends PlayerCommand{
+public class UpdateReinforcements extends PlayerCommandMiddle{
 
 	private GroupManager gm = NameAPI.getGroupManager();
 	
@@ -40,16 +39,17 @@ public class UpdateReinforcements extends PlayerCommand{
 		}
 		Player p = (Player) sender;
 		if (!p.hasPermission("citadel.admin") || !p.isOp()){
-			return false;
+			sendAndLog(p, ChatColor.RED, "Nice try");
+			return true;
 		}
 		
 		if (args.length == 0){
-			p.sendMessage(ChatColor.GREEN + "Searching for groups in current chunk.");
+			sendAndLog(p, ChatColor.GREEN, "Searching for groups in current chunk.");
 			Bukkit.getScheduler().runTaskAsynchronously(Citadel.getInstance(), new FindGroups(p, p.getLocation()));
 			return true;
 		}
 		else if (args.length == 1){
-			p.sendMessage(ChatColor.RED + "Please enter two groups.");
+			sendAndLog(p, ChatColor.RED, "Please enter two groups.");
 			return true;
 		}
 		
@@ -57,12 +57,12 @@ public class UpdateReinforcements extends PlayerCommand{
 		Group n = gm.getGroup(args[1]);
 		
 		if (old == null || n == null){
-			p.sendMessage(ChatColor.RED + "One of the groups does not exist.");
+			sendAndLog(p, ChatColor.RED, "One of the groups does not exist.");
 			return true;
 		}
 		
+		sendAndLog(p, ChatColor.GREEN, "Beginning to change groups.");
 		Bukkit.getScheduler().runTaskAsynchronously(Citadel.getInstance(), new UpdateGroups(p, p.getLocation().getChunk(), old, n));
-		p.sendMessage(ChatColor.GREEN + "Beginning to change groups.");
 		return true;
 	}
 
@@ -91,19 +91,21 @@ public class UpdateReinforcements extends PlayerCommand{
 			for (Reinforcement r: reins){
 				if (r instanceof PlayerReinforcement){
 					PlayerReinforcement rein = (PlayerReinforcement) r;
-					if (rein.getGroup().getName().equals(old.getName()))
+					if (rein.getGroup().getName().equals(old.getName())) {
 						rein.setGroup(n);
+					}
 				}
 				else if (r instanceof MultiBlockReinforcement){
 					MultiBlockReinforcement rein = (MultiBlockReinforcement) r;
-					if (rein.getGroup().getName().equals(old.getName()))
+					if (rein.getGroup().getName().equals(old.getName())) {
 						rein.setGroup(n);
+					}
 				}
 			}
 			if (!p.isOnline())
 				return;
 			
-			p.sendMessage(ChatColor.GREEN + "The groups have been updated.");
+			sendAndLog(p, ChatColor.GREEN, "The groups have been updated.");
 		}
 		
 	}
@@ -127,25 +129,29 @@ public class UpdateReinforcements extends PlayerCommand{
 				if (r instanceof PlayerReinforcement){
 					PlayerReinforcement rein = (PlayerReinforcement) r;
 					String name = rein.getGroup().getName();
-					if (groups.contains(name))
+					if (groups.contains(name)) {
 						continue;
+					}
 					groups.add(name);
 				}
 				else if (r instanceof MultiBlockReinforcement){
 					MultiBlockReinforcement rein = (MultiBlockReinforcement) r;
 					String name = rein.getGroup().getName();
-					if (groups.contains(name))
+					if (groups.contains(name)) {
 						continue;
+					}
 					groups.add(name);
 				}
 			}
-			if (!p.isOnline())
+			if (!p.isOnline()) {
 				return;
-			String names = "";
-			for (String g: groups)
-				names += g + " ";
+			}
+			StringBuilder names = new StringBuilder();
+			for (String g: groups) {
+				names.append(g).append(" ");
+			}
 			
-			p.sendMessage(ChatColor.GREEN + "The groups in this chunk are: " + names);
+			sendAndLog(p, ChatColor.GREEN, "The groups in this chunk are: " + names);
 		}
 		
 	}

--- a/src/vg/civcraft/mc/citadel/database/CitadelReinforcementData.java
+++ b/src/vg/civcraft/mc/citadel/database/CitadelReinforcementData.java
@@ -8,22 +8,22 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
-import org.bukkit.ChunkSnapshot;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import vg.civcraft.mc.citadel.Citadel;
+import vg.civcraft.mc.citadel.CitadelConfigManager;
 import vg.civcraft.mc.citadel.reinforcement.MultiBlockReinforcement;
 import vg.civcraft.mc.citadel.reinforcement.NaturalReinforcement;
 import vg.civcraft.mc.citadel.reinforcement.PlayerReinforcement;
 import vg.civcraft.mc.citadel.reinforcement.Reinforcement;
 import vg.civcraft.mc.namelayer.GroupManager;
-import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.group.Group;
 
 public class CitadelReinforcementData {
@@ -90,40 +90,10 @@ public class CitadelReinforcementData {
 				try {
 					Thread.sleep(10000);
 				} catch (InterruptedException e1) {
-					// TODO Auto-generated catch block
-					e1.printStackTrace();
+					Citadel.getInstance().getLogger().log(Level.SEVERE, "Update sleep interrupted", e1);
 				}
 				long first_time = System.currentTimeMillis();
 				db.execute("alter table reinforcement drop security_level, drop version, add group_id int not null;");
-				/*
-				Citadel.Log("Remapping from material id to material name " +
-						"in process.");
-				db.execute("create table if not exists material_mapping("
-						+ "" +
-						"material varchar(40) not null," +
-						"material_id int not null);");
-				db.execute("create index x on material_mapping (material_id);");
-				for (Material mat: Material.values()){
-					PreparedStatement insert = db.prepareStatement
-							("insert into material_mapping(" +
-							"material, material_id) values(?,?);");
-					try {
-						insert.setString(1, mat.name());
-						insert.setInt(2, mat.getId());
-						insert.execute();
-					} catch (SQLException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}
-				}
-				db.execute("alter table reinforcement add " +
-						"material varchar(10)");
-				db.execute("update reinforcement r " +
-						"inner join material_mapping m on m.material_id = r.material_id " +
-						"set r.material = m.material;");
-				db.execute("alter table reinforcement drop material_id;");
-				db.execute("drop table material_mapping;");
-				*/
 				db.execute("insert into faction_id (group_name) values (null);"); // For natural reinforcements
 				db.execute("delete from reinforcement where `name` is null;");
 				db.execute("update ignore reinforcement r inner join faction_id f on f.group_name = r.`name` "
@@ -156,9 +126,10 @@ public class CitadelReinforcementData {
 					+ "rein_type varchar(30) not null,"
 					+ "primary key rein_type_key (rein_type_id));");
 			String[] types = {"PlayerReinforcement", "NaturalReinforcement", "MultiBlockReinforcement"};
-			for (String x: types)
+			for (String x: types) {
 				db.execute(String.format("insert into reinforcement_type(rein_type)"
 						+ "values('%s');", x));
+			}
 			updateVersion(5, plugin.getName());
 			ver = checkVersion(plugin.getName());
 			Citadel.Log("The update to Version 6 took " + (System.currentTimeMillis() - first_time) / 1000 + " seconds.");
@@ -216,8 +187,12 @@ public class CitadelReinforcementData {
 	 * Reconnects and reinitializes the mysql connection and preparedstatements.
 	 */
 	private void reconnectAndReinitialize(){
-		if (db.isConnected())
+		if (db.isConnected()) {
 			return;
+		}
+		if (CitadelConfigManager.shouldLogInternal()) {
+			Citadel.Log("Database went away, reconnecting.");
+		}
 		db.connect();
 		initalizePreparedStatements();
 	}
@@ -256,16 +231,6 @@ public class CitadelReinforcementData {
 				+ "set r.durability = ?, r.insecure = ?, r.group_id = ?, "
 				+ "maturation_time = ?, acid_time = ? "
 				+ "where ri.x = ? and ri.y = ? and ri.z = ? and ri.world =?";
-		/*
-		deleteGroup = db.prepareStatement("call deleteGroup(?)");
-		insertDeleteGroup = db.prepareStatement("insert into toDeleteReinforecments(group_id) select g.group_id from faction_id g "
-				+ "where g.group_name = ?");
-		removeDeleteGroup = db.prepareStatement("delete from toDeleteReinforecments where group_id = (select f.group_id from "
-				+ "faction_id f where f.group_name = ?)");
-		getDeleteGroup = db.prepareStatement("select f.group_name from faction_id f "
-				+ "inner join toDeleteReinforecments d on f.group_id = d.group_id");
-		*/
-		
 		insertReinID = "call insertReinID(?,?,?,?,?)";
 		insertCustomReinID = "call insertCustomReinID(?,?,?,?,?,?)";
 		getCordsbyReinID = "select x, y, z, world from reinforcement_id where rein_id = ?";
@@ -293,7 +258,9 @@ public class CitadelReinforcementData {
 				return 0;
 			return set.getInt("db_version");
 		} catch (SQLException e) {
-			// table doesnt exist
+			if (CitadelConfigManager.shouldLogInternal()) {
+				Citadel.getInstance().getLogger().log(Level.WARNING, "Version control table missing for Citadel!", e);
+			}
 			return 0;
 		}
 	}
@@ -315,8 +282,7 @@ public class CitadelReinforcementData {
 			updateVersion.setString(3, pluginname);
 			updateVersion.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			Citadel.getInstance().getLogger().log(Level.WARNING, "Version control table error; unable to update DB version for Citadel!", e);
 		}
 		return ++version;
 	}
@@ -330,6 +296,11 @@ public class CitadelReinforcementData {
 	 * @return Returns null if there is no reinforcement.
 	 */
 	public Reinforcement getReinforcement(Location loc){
+		if (loc == null){
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"CitadelReinforcementData getReinforcement called with null");
+			return null;
+		}
 		reconnectAndReinitialize();
 		PreparedStatement getRein = db.prepareStatement(this.getRein);
 		try {
@@ -343,10 +314,11 @@ public class CitadelReinforcementData {
 			getRein.setString(4, formatChunk);
 			getRein.setString(5, loc.getWorld().getName());
 			ResultSet set = getRein.executeQuery();
-			if (!set.next()){
+			if (!set.next()) {
 				set.close();
 				return null;
 			}
+			@SuppressWarnings("deprecation")
 			Material mat = Material.getMaterial(set.getInt(1));
 			int durability = set.getInt(2);
 			boolean inSecure = set.getBoolean(3);
@@ -355,36 +327,40 @@ public class CitadelReinforcementData {
 			String rein_type = set.getString(6);
 			String lore = set.getString(7);
 			int group_id = set.getInt(8);
-			// Check for what type of reinforcement and return the one
-			// needed.
-			if (rein_type.equals("PlayerReinforcement")){
+			// Check for what type of reinforcement and return the one needed.
+			if ("PlayerReinforcement".equals(rein_type)) {
+				set.close();
 				ItemStack stack = new ItemStack(mat);
-				if (lore != null){
+				if (lore != null) {
 					ItemMeta meta = stack.getItemMeta();
 					List<String> array = Arrays.asList(lore.split("\n"));
 					meta.setLore(array);
 					stack.setItemMeta(meta);
 				}
-				PlayerReinforcement rein =
-						new PlayerReinforcement(loc, durability,
-								mature, acid, GroupManager.getGroup(group_id),
-								stack);
+				Group g = GroupManager.getGroup(group_id);
+				if (g == null) {
+					if (CitadelConfigManager.shouldLogReinforcement()) {
+						Citadel.getInstance().getLogger().log(Level.WARNING,
+								"Player Reinforcement at {0} lacks a valid group (group {1} failed lookup)", 
+								new Object[] {loc, group_id});
+					}
+					return null; // group not found!
+				}
+				PlayerReinforcement rein = new PlayerReinforcement(loc, durability, 
+							mature, acid, g,stack);
 				rein.setInsecure(inSecure);
-				set.close();
 				return rein;
-			}
-			else if(rein_type.equals("NaturalReinforcement")){
-				NaturalReinforcement rein = 
-						new NaturalReinforcement(loc.getBlock(), durability);
+			} else if ("NaturalReinforcement".equals(rein_type)){
 				set.close();
+				NaturalReinforcement rein = new NaturalReinforcement(loc.getBlock(), durability);
 				return rein;
-			}
-			else if (rein_type.equals("MultiBlockReinforcement")){
+			} else if ("MultiBlockReinforcement".equals(rein_type)) {
 				int id = set.getInt(9);
 				set.close();
 				MultiBlockReinforcement rein = MultiBlockReinforcement.getMultiRein(id);
-				if (rein != null)
+				if (rein != null) {
 					return rein;
+				}
 				PreparedStatement getCordsbyReinID = db.prepareStatement(this.getCordsbyReinID);
 				getCordsbyReinID.setInt(1, id);
 				set = getCordsbyReinID.executeQuery();
@@ -395,12 +371,25 @@ public class CitadelReinforcementData {
 					locs.add(new Location(Bukkit.getWorld(world), xx, yy, zz));
 				}
 				set.close();
-				
-				rein = new MultiBlockReinforcement(locs, GroupManager.getGroup(group_id), durability, mature, acid, id);
+
+				Group g = GroupManager.getGroup(group_id);
+				if (g == null) {
+					if (CitadelConfigManager.shouldLogReinforcement()) {
+						Citadel.getInstance().getLogger().log(Level.WARNING,
+								"Multiblock Reinforcement touching {0} lacks a valid group (group {1} failed lookup)", 
+								new Object[] {loc, group_id});
+					}
+					return null; // group not found!
+				}
+				rein = new MultiBlockReinforcement(locs, g, durability, mature, acid, id);
 				return rein;
 			}
 		} catch (SQLException e) {
-			e.printStackTrace();
+			Citadel.getInstance().getLogger().log(Level.SEVERE, "Failed while retrieving reinforcement from database", e);
+		}
+		if (CitadelConfigManager.shouldLogInternal()) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"CitadelReinforcementData getReinforcement failed for {0}", loc);
 		}
 		return null;
 	}
@@ -411,16 +400,26 @@ public class CitadelReinforcementData {
 	 * @return A list of reinforcements in a chunk
 	 */
 	public List<Reinforcement> getReinforcements(Chunk chunk){
+		if (chunk == null){
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"CitadelReinforcementData getReinforcements called with null");
+			return null;
+		}
 		reconnectAndReinitialize();
 		PreparedStatement getReins = db.prepareStatement(this.getReins);
 		String formatChunk = formatChunk(chunk);
+		if (CitadelConfigManager.shouldLogInternal()) {
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"CitadelReinforcementData getReinforcements chunk called for {0}", formatChunk);
+		}
 		List<Reinforcement> reins = new ArrayList<Reinforcement>();
 		try {
 			getReins.setString(1, formatChunk);
 			ResultSet set = getReins.executeQuery();
-			while (set.next()){
+			while (set.next()) {
 				int x = set.getInt(1), y = set.getInt(2), z = set.getInt(3);
 				String world = set.getString(4);
+				@SuppressWarnings("deprecation")
 				Material mat = Material.getMaterial(set.getInt(5));
 				int durability = set.getInt(6);
 				boolean inSecure = set.getBoolean(7);
@@ -428,12 +427,20 @@ public class CitadelReinforcementData {
 				String rein_type = set.getString(9);
 				String lore = set.getString(10);
 				int group_id = set.getInt(11);
-				Group g = GroupManager.getGroup(group_id);
 				int acid = set.getInt(13);
 				
 				Location loc = new Location(Bukkit.getWorld(world), x, y, z);
 				
-				if (rein_type.equals("PlayerReinforcement")){
+				if ("PlayerReinforcement".equals(rein_type)){
+					Group g = GroupManager.getGroup(group_id);
+					if (g == null) {
+						if (CitadelConfigManager.shouldLogReinforcement()) {
+							Citadel.getInstance().getLogger().log(Level.WARNING,
+									"During Chunk {0} load, Player Reinforcement at {1} lacks a valid group (group {2} failed lookup)", 
+									new Object[] {formatChunk, loc, group_id});
+						}
+						continue; // group not found!
+					}
 					ItemStack stack = new ItemStack(mat);
 					if (lore != null){
 						ItemMeta meta = stack.getItemMeta();
@@ -441,23 +448,32 @@ public class CitadelReinforcementData {
 						meta.setLore(array);
 						stack.setItemMeta(meta);
 					}
-					PlayerReinforcement rein =
-							new PlayerReinforcement(loc, durability,
-									mature, acid, g,
-									stack);
+					PlayerReinforcement rein = new PlayerReinforcement(loc, durability,
+									mature, acid, g, stack);
 					rein.setInsecure(inSecure);
 					reins.add(rein);
 				}
-				else if(rein_type.equals("NaturalReinforcement")){
-					NaturalReinforcement rein = 
-							new NaturalReinforcement(loc.getBlock(), durability);
+				else if("NaturalReinforcement".equals(rein_type)){
+					NaturalReinforcement rein = new NaturalReinforcement(loc.getBlock(), durability);
 					reins.add(rein);
 				}
-				else if (rein_type.equals("MultiBlockReinforcement")){
+				else if ("MultiBlockReinforcement".equals(rein_type)){
 					int id = set.getInt(12);
 					MultiBlockReinforcement rein = MultiBlockReinforcement.getMultiRein(id);
-					if (rein != null)
+					if (rein != null) {
 						reins.add(rein);
+						continue;
+					}
+					
+					Group g = GroupManager.getGroup(group_id);
+					if (g == null) {
+						if (CitadelConfigManager.shouldLogReinforcement()) {
+							Citadel.getInstance().getLogger().log(Level.WARNING,
+									"During Chunk {0} load, Multiblock Reinforcement at {1} lacks a valid group (group {2} failed lookup)", 
+									new Object[] {formatChunk, loc, group_id});
+						}
+						continue; // group not found!
+					}
 					PreparedStatement getCordsbyReinID = db.prepareStatement(this.getCordsbyReinID);
 					getCordsbyReinID.setInt(1, id);
 					ResultSet multi = getCordsbyReinID.executeQuery();
@@ -475,18 +491,27 @@ public class CitadelReinforcementData {
 			}
 			set.close();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			Citadel.getInstance().getLogger().log(Level.SEVERE, "Failed while retrieving chunk " + 
+					formatChunk + " reinforcement from database", e);
 		}
 		return reins;
 	}
 	
 	/**
-	 * Inserts a reinforcement into the Database.  Should only be called from
-	 * SaveManager.
+	 * Inserts a reinforcement into the Database. Should only be called from SaveManager.
 	 * @param The Reinforcement to save.
 	 */
 	public void insertReinforcement(Reinforcement rein){
+		insertReinforcement(rein, false);
+	}
+	
+	@SuppressWarnings("deprecation")
+	public void insertReinforcement(Reinforcement rein, boolean retry){
+		if (rein == null){
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"CitadelReinforcementData insertReinforcement called with null");
+			return;
+		}
 		reconnectAndReinitialize();
 		
 		if (rein instanceof PlayerReinforcement){
@@ -498,19 +523,26 @@ public class CitadelReinforcementData {
 			int maturationTime = rein.getMaturationTime();
 			int acidTime = rein.getAcidTime();
 			boolean insecure = false;
-			String group = null;
-			String reinType = "";
-			String lore = "";
+			String reinType = "PlayerReinforcement";
+			
 			PlayerReinforcement pRein = (PlayerReinforcement) rein;
 			insecure = pRein.isInsecure();
 			ItemMeta meta = pRein.getStackRepresentation().getItemMeta();
-			if (meta.hasLore())
-				for (String xx: meta.getLore())
+			String lore = "";
+			if (meta.hasLore()) {
+				for (String xx: meta.getLore()) {
 					lore += xx + "\n";
-			else
+				}
+			} else {
 				lore = null;
-			group = pRein.getGroup().getName();
-			reinType = "PlayerReinforcement";
+			}
+			
+			Group g = pRein.getGroup(); 
+			if (g == null) {
+				Citadel.getInstance().getLogger().log(Level.WARNING,
+						"Player Reinforcement insert at {0} lacks a valid group (lookup failed)", loc);
+			}
+			
 			try {
 				PreparedStatement insertReinID = db.prepareStatement(this.insertReinID);
 				insertReinID.setInt(1, x);
@@ -520,8 +552,9 @@ public class CitadelReinforcementData {
 				insertReinID.setString(4, formatChunk);
 				insertReinID.setString(5, world);
 				ResultSet set = insertReinID.executeQuery();
-				set.next();
-				
+				if (!set.next()) {
+					throw new SQLException("Failed ID insertion");
+				}
 				int id = set.getInt("id");
 				
 				PreparedStatement addRein = db.prepareStatement(this.addRein);
@@ -536,18 +569,19 @@ public class CitadelReinforcementData {
 				addRein.setString(9, reinType);
 				addRein.execute();
 			} catch (SQLException e) {
-				Citadel.Log("Citadel has detected a reinforcement that should not be there. Deleting it and trying again. "
-						+ "Including the stack incase it is useful.\n" + e.getStackTrace());
-				// Let's delete the reinforcement because if a user 
-				//is able to place one then the db is messed up some how.
+				Citadel.getInstance().getLogger().log(Level.SEVERE, "Citadel has detected a reinforcement that should not be there. Deleting it and trying again. "
+						+ "Including the stack incase it is useful.", e);
+				// Let's delete the reinforcement; if a user is able to place one then the db is
+				// out of synch / messed up some how.
 				deleteReinforcement(rein);
 				// Now lets try again.
-				insertReinforcement(rein);
+				if (!retry) {
+					insertReinforcement(rein, true);
+				}
 			}
-		}
-		else if (rein instanceof NaturalReinforcement){
+		} else if (rein instanceof NaturalReinforcement) {
 			/* 
-			 * Why removed? We had thoughts of using this..
+			 * TODO: Why removed? We had thoughts of using this..
 			 *
 			 * We don't need to worry about saving this right now.
 			 * 
@@ -592,42 +626,57 @@ public class CitadelReinforcementData {
 				e.printStackTrace();
 			}
 			*/
-		}
-		else if (rein instanceof MultiBlockReinforcement){
+		} else if (rein instanceof MultiBlockReinforcement){
 			MultiBlockReinforcement mbRein = (MultiBlockReinforcement) rein;
 
+			Group g = mbRein.getGroup();  // let's confirm it's good.
+			if (g == null) {
+				Citadel.getInstance().getLogger().log(Level.WARNING,
+						"Multiblock Reinforcement insert request lacks a valid group (lookup failed)");
+			}
+			
 			int id = -1; // We add one because we haven't added it yet.
 			try {
 				PreparedStatement insertCustomReinID = db.prepareStatement(this.insertCustomReinID);
 				// add all the locations into the db.
 				int count = 0;
-				for (Location lo: mbRein.getLocations()){
-					if (count == 0) {
-						PreparedStatement insertReinID = db.prepareStatement(this.insertReinID);
-						insertReinID.setInt(1, lo.getBlockX());
-						insertReinID.setInt(2, lo.getBlockY());
-						insertReinID.setInt(3, lo.getBlockZ());
+				try {
+					for (Location lo: mbRein.getLocations()){
+						if (count == 0) {
+							PreparedStatement insertReinID = db.prepareStatement(this.insertReinID);
+							insertReinID.setInt(1, lo.getBlockX());
+							insertReinID.setInt(2, lo.getBlockY());
+							insertReinID.setInt(3, lo.getBlockZ());
+							String formatChunk = formatChunk(lo);
+							insertReinID.setString(4, formatChunk);
+							insertReinID.setString(5, lo.getWorld().getName());
+							ResultSet set = insertReinID.executeQuery();
+							if (!set.next()) {
+								throw new SQLException("Failed ID insertion");
+							}
+							
+							id = set.getInt("id");
+							mbRein.setReinId(id);
+							continue;
+						}
+						insertCustomReinID.setInt(1, id);
+						insertCustomReinID.setInt(2, lo.getBlockX());
+						insertCustomReinID.setInt(3, lo.getBlockY());
+						insertCustomReinID.setInt(4, lo.getBlockZ());
 						String formatChunk = formatChunk(lo);
-						insertReinID.setString(4, formatChunk);
-						insertReinID.setString(5, lo.getWorld().getName());
-						ResultSet set = insertReinID.executeQuery();
-						set.next();
-						
-						id = set.getInt("id");
-						mbRein.setReinId(id);
-						continue;
+						insertCustomReinID.setString(5, formatChunk);
+						insertCustomReinID.setString(6, lo.getWorld().getName());
+						insertCustomReinID.addBatch();
 					}
-					insertCustomReinID.setInt(1, id);
-					insertCustomReinID.setInt(2, lo.getBlockX());
-					insertCustomReinID.setInt(3, lo.getBlockY());
-					insertCustomReinID.setInt(4, lo.getBlockZ());
-					String formatChunk = formatChunk(lo);
-					insertCustomReinID.setString(5, formatChunk);
-					insertCustomReinID.setString(6, lo.getWorld().getName());
-					insertCustomReinID.addBatch();
+					insertCustomReinID.executeBatch();
+				} catch (SQLException se) {
+					Citadel.getInstance().getLogger().log(Level.SEVERE, "Citadel has failed to insert locations in a" +
+							" multiblock reinforcement insertion. ", se);
+					insertCustomReinID.clearBatch();
+					// TODO: Consider forcing the reinf ID removal.
+					throw se; // propagate the exception.
 				}
-				insertCustomReinID.executeBatch();
-				
+
 				PreparedStatement addRein = db.prepareStatement(this.addRein);
 				addRein.setInt(1, -1);
 				addRein.setInt(2, mbRein.getDurability());
@@ -640,8 +689,13 @@ public class CitadelReinforcementData {
 				addRein.setString(9, "MultiBlockReinforcement");
 				addRein.execute();
 			} catch (SQLException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				Citadel.getInstance().getLogger().log(Level.SEVERE, "Citadel has failed to insert a" +
+						" multiblock reinforcement. ", e);
+				deleteReinforcement(rein);
+				// Now lets try again.
+				if (!retry) {
+					insertReinforcement(rein);
+				}
 			}
 		}
 		
@@ -652,6 +706,11 @@ public class CitadelReinforcementData {
 	 * @param The Reinforcement to delete.
 	 */
 	public void deleteReinforcement(Reinforcement rein){
+		if (rein == null){
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"CitadelReinforcementData deleteReinforcement called with null");
+			return;
+		}
 		reconnectAndReinitialize();
 		
 		Location loc = rein.getLocation();
@@ -665,16 +724,22 @@ public class CitadelReinforcementData {
 			removeRein.setString(4, world);
 			removeRein.execute();
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			Citadel.getInstance().getLogger().log(Level.SEVERE, "Citadel has failed to delete a" +
+					" reinforcement at "+ loc, e);
 		}
 	}
+
 	/**
 	 * Saves the Reinforcement to the Database. Should only be called
 	 * from SaveManager.
 	 * @param The Reinforcement to save.
 	 */
 	public void saveReinforcement(Reinforcement rein){
+		if (rein == null){
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"CitadelReinforcementData saveReinforcement called with null");
+			return;
+		}
 		reconnectAndReinitialize();
 		
 		int dur = rein.getDurability();
@@ -688,12 +753,24 @@ public class CitadelReinforcementData {
 		if (rein instanceof PlayerReinforcement){
 			PlayerReinforcement pRein = (PlayerReinforcement) rein;
 			insecure = pRein.isInsecure();
-			groupId = pRein.getGroup().getGroupId();
+			Group g = pRein.getGroup();
+			if (g == null) {
+				Citadel.getInstance().getLogger().log(Level.WARNING,
+						"Player saveReinforcement at {0} lacks a valid group (lookup failed)", loc);
+			} else {
+				groupId = g.getGroupId();
+			}
 		}
 		if (rein instanceof MultiBlockReinforcement){
 			MultiBlockReinforcement mbRein = (MultiBlockReinforcement) rein;
 			insecure = false;
-			groupId = mbRein.getGroup().getGroupId();
+			Group g = mbRein.getGroup();
+			if (g == null) {
+				Citadel.getInstance().getLogger().log(Level.WARNING,
+						"Player saveinsert at {0} lacks a valid group (lookup failed)", loc);
+			} else {
+				groupId = g.getGroupId();
+			}			
 		}
 		try {
 			PreparedStatement updateRein = db.prepareStatement(this.updateRein);
@@ -708,99 +785,41 @@ public class CitadelReinforcementData {
 			updateRein.setString(9, world);
 			updateRein.execute();
 		} catch (SQLException e) {
-			Citadel.Log(String.format("The Null Group Exception that is being followed has to deal with the group id: %s,"
-					+ " at location: %d, %d, %d, at world: %s", groupId, x, y, z, world));
-			e.printStackTrace();
+			Citadel.getInstance().getLogger().log(Level.WARNING, String.format("The Null Group Exception that is being followed has to deal with the group id: %s,"
+					+ " at location: %d, %d, %d, at world: %s", groupId, x, y, z, world), e);
 		}
 	}
-	
-	/*
-	/**
-	 * Begins deleting the reinforcements at a group. Once this is executed
-	 * the specified group loses all reinforcements. They are removed from map,
-	 * no longer able to be bypassed or broken.
-	 * @param The Group name that is being removed.
-	 * @return Returns true if there are more records to remove, false otherwise.
-	 *
-	public boolean deleteGroup(String group){
-		reconnectAndReinitialize();
-		
-		try {
-			deleteGroup.setString(1, group);
-			ResultSet set = deleteGroup.executeQuery();
-			set.next();
-			return set.getInt(1) > 0;
-		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return true;
-	}
-	
-	public void insertDeleteGroup(String group){
-		reconnectAndReinitialize();
-		
-		try {
-			insertDeleteGroup.setString(1, group);
-			insertDeleteGroup.execute();
-		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
-	
-	public List<Group> getDeleteGroups(){
-		reconnectAndReinitialize();
-		
-		List<Group> groups = new ArrayList<Group>();
-		try {
-			ResultSet set = getDeleteGroup.executeQuery();
-			while (set.next())
-				groups.add(GroupManager.getGroup(set.getString(1)));
-		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return groups;
-	}
-	
-	public void removeDeleteGroup(String group){
-		reconnectAndReinitialize();
-		
-		try {
-			removeDeleteGroup.setString(1, group);
-			removeDeleteGroup.execute();
-		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
-	*/
 	
 	private String formatChunk(Location loc){
-		String chunk = loc.getWorld().getName();
 		Chunk c = loc.getChunk();
-		chunk += ":" + c.getX() + ":" + c.getZ();
-		return chunk;
+		return formatChunk(c);
 	}
 	
 	private String formatChunk(Chunk c){
-		String chunk = c.getWorld().getName();
-		chunk += ":" + c.getX() + ":" + c.getZ();
-		return chunk;
+		StringBuilder chunk = new StringBuilder(c.getWorld().getName());
+		chunk.append(":").append(c.getX()).append(":").append(c.getZ());
+		return chunk.toString();
 	}
 	
 	public int getReinCountForGroup(String group){
+		if (group == null){
+			Citadel.getInstance().getLogger().log(Level.WARNING,
+					"CitadelReinforcementData getReinCountForGroup called with null");
+			return 0;
+		}
 		try {
 			PreparedStatement selectReinCountForGroup = db.prepareStatement(this.selectReinCountForGroup);
 			selectReinCountForGroup.setString(1, group);
 			ResultSet set = selectReinCountForGroup.executeQuery();
-			set.next();
+			if (!set.next()) {
+				throw new SQLException("Failed Count");
+			}
+			int r = set.getInt(1);
 			set.close();
-			return set.getInt(1);
+			return r;
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			Citadel.getInstance().getLogger().log(Level.SEVERE, "getReinCountForGroup has failed for " +
+					group, e);
 		}
 		return 0;
 	}
@@ -809,12 +828,14 @@ public class CitadelReinforcementData {
 		try {
 			PreparedStatement selectReinCount = db.prepareStatement(this.selectReinCount);
 			ResultSet set = selectReinCount.executeQuery();
-			set.next();
+			if (!set.next()) {
+				throw new SQLException("Failed Count");
+			}
+			int r = set.getInt(1);
 			set.close();
-			return set.getInt(1);
+			return r;
 		} catch (SQLException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			Citadel.getInstance().getLogger().log(Level.SEVERE, "getReinCountForAllGroups has failed", e);
 		}
 		return 0;
 	}

--- a/src/vg/civcraft/mc/citadel/listener/EntityListener.java
+++ b/src/vg/civcraft/mc/citadel/listener/EntityListener.java
@@ -6,6 +6,7 @@ import static vg.civcraft.mc.citadel.Utility.maybeReinforcementDamaged;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -68,7 +69,7 @@ public class EntityListener implements Listener{
 	                iterator.remove();
 	            }
             } catch (NoClassDefFoundError e){
-            	Citadel.Log("NoClassDefFoundError");
+            	Citadel.getInstance().getLogger().log(Level.WARNING, "Class Definition not found in explode", e);
             }
         }
     }

--- a/src/vg/civcraft/mc/citadel/misc/CitadelStatics.java
+++ b/src/vg/civcraft/mc/citadel/misc/CitadelStatics.java
@@ -61,13 +61,13 @@ public enum CitadelStatics {
 	}
 	
 	public static void displayStatisticsToConsole(){
-		String stats = "Citadel Reinforcement Stats:\n";
-		stats += "Reinforcements loaded from db " + reins_loaded_from_db + ".\n";
-		stats += "Reinforcements loaded from cache " + reins_called_from_cache + ".\n";
-		stats += "Total Reinforcement calls " + (reins_called_from_cache + reins_loaded_from_db) + ".\n";
-		stats += "Amount of Reinforcement saves " + reins_updated_to_db + ".\n";
-		stats += "Reinforcements deleted from the db " + reins_deleted_from_db + ".\n";
-		stats += "Reinforcements created and saved to db " + reins_insert_to_db + ".\n";
-		Citadel.Log(stats);
+		StringBuilder stats = new StringBuilder("Citadel Reinforcement Stats:\n");
+		stats.append("  Reinforcements loaded from db ").append(reins_loaded_from_db).append(".\n");
+		stats.append("  Reinforcements loaded from cache ").append(reins_called_from_cache).append(".\n");
+		stats.append("  Total Reinforcement calls ").append(reins_called_from_cache + reins_loaded_from_db).append(".\n");
+		stats.append("  Amount of Reinforcement saves ").append(reins_updated_to_db).append(".\n");
+		stats.append("  Reinforcements deleted from the db ").append(reins_deleted_from_db).append(".\n");
+		stats.append("  Reinforcements created and saved to db ").append(reins_insert_to_db).append(".\n");
+		Citadel.Log(stats.toString());
 	}
 }

--- a/src/vg/civcraft/mc/citadel/reinforcement/MultiBlockReinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/MultiBlockReinforcement.java
@@ -3,6 +3,7 @@ package vg.civcraft.mc.citadel.reinforcement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.bukkit.Location;
 
@@ -42,8 +43,23 @@ public class MultiBlockReinforcement extends Reinforcement{
 	}
 	
 	public Group getGroup(){
+		checkValid();
 		return g;
 	}
+	
+    private void checkValid(){
+    	if (g == null) {
+    		Citadel.getInstance().getLogger().log(Level.WARNING, "CheckValid was called but the underlying group is gone for " + this.getLocation() + "!");
+    		return;
+    	}
+    	if (!g.isValid()){ // incase it was recently merged/ deleted.
+    		g = NameAPI.getGroupManager().getGroup(g.getGroupId());
+    		if (g == null) {
+    			Citadel.getInstance().getLogger().log(Level.INFO, "Group " + g.getGroupId() + " was deleted or merged but not marked invalid!");
+    		}
+    		isDirty = true;
+    	}
+    }
 	/**
 	 * This method is used to get the MultiblockReinforcement from a
 	 * particular id. The id is the one from the db.

--- a/src/vg/civcraft/mc/citadel/reinforcement/NaturalReinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/NaturalReinforcement.java
@@ -8,4 +8,5 @@ public class NaturalReinforcement extends Reinforcement{
 		super(block.getLocation(), block.getType(), dur, 0, 0);
 		// The group is null be natural reinforcements don't belong to a group.
 	}
+
 }

--- a/src/vg/civcraft/mc/citadel/reinforcement/PlayerReinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/PlayerReinforcement.java
@@ -178,9 +178,17 @@ public class PlayerReinforcement extends Reinforcement{
     }
     
     private void checkValid(){
+    	if (g == null) {
+    		Citadel.getInstance().getLogger().log(Level.WARNING, "CheckValid was called but the underlying group is gone for " + this.getLocation() + "!");
+    		return;
+    	}
     	if (!g.isValid()){ // incase it was recently merged/ deleted.
     		g = NameAPI.getGroupManager().getGroup(g.getGroupId());
-    		gp = NameAPI.getGroupManager().getPermissionforGroup(g);
+    		if (g != null) {
+    			gp = NameAPI.getGroupManager().getPermissionforGroup(g);
+    		} else {
+    			Citadel.getInstance().getLogger().log(Level.INFO, "Group " + g.getGroupId() + " was deleted or merged but not marked invalid!");
+    		}
     		isDirty = true;
     	}
     }

--- a/src/vg/civcraft/mc/citadel/reinforcement/Reinforcement.java
+++ b/src/vg/civcraft/mc/citadel/reinforcement/Reinforcement.java
@@ -87,4 +87,8 @@ public class Reinforcement {
 	public void setDirty(boolean dirty){
 		isDirty = dirty;
 	}
+	
+	public Material getType() {
+		return this.mat;
+	}
 }

--- a/src/vg/civcraft/mc/citadel/reinforcementtypes/NaturalReinforcementType.java
+++ b/src/vg/civcraft/mc/citadel/reinforcementtypes/NaturalReinforcementType.java
@@ -2,9 +2,11 @@ package vg.civcraft.mc.citadel.reinforcementtypes;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.bukkit.Material;
 
+import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.CitadelConfigManager;
 
 public class NaturalReinforcementType {
@@ -26,6 +28,10 @@ public class NaturalReinforcementType {
 			Material mat = CitadelConfigManager.getNaturalReinforcementMaterial(type);
 			int dur = CitadelConfigManager.getNaturalReinforcementHitPoints(type);
 			new NaturalReinforcementType(mat, dur);
+			if (CitadelConfigManager.shouldLogInternal()) {
+				Citadel.getInstance().getLogger().log(Level.INFO, "Adding Natural Reinforcement: {0} w/ health {1}", 
+						new Object[] {mat.toString(), dur});
+			}
 		}
 	}
 	/**

--- a/src/vg/civcraft/mc/citadel/reinforcementtypes/NonReinforceableType.java
+++ b/src/vg/civcraft/mc/citadel/reinforcementtypes/NonReinforceableType.java
@@ -2,9 +2,11 @@ package vg.civcraft.mc.citadel.reinforcementtypes;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 import org.bukkit.Material;
 
+import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.CitadelConfigManager;
 
 public class NonReinforceableType {
@@ -15,6 +17,9 @@ public class NonReinforceableType {
 		List<String> materials = CitadelConfigManager.getNonReinforceableTypes();
 		for (String x: materials){
 			mats.add(Material.getMaterial(x));
+			if (CitadelConfigManager.shouldLogInternal()) {
+				Citadel.getInstance().getLogger().log(Level.INFO, "Adding Non-reinforceable: {0}", x);
+			}
 		}
 	}
 	

--- a/src/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementType.java
+++ b/src/vg/civcraft/mc/citadel/reinforcementtypes/ReinforcementType.java
@@ -4,11 +4,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.CitadelConfigManager;
 
 public class ReinforcementType {
@@ -59,6 +61,13 @@ public class ReinforcementType {
 			List<String> lore = CitadelConfigManager.getLoreValues(type);
 			new ReinforcementType(mat, amount, percentReturn, returnValue,
 					hitpoints, maturation, acid, maturation_scale, lore);
+			if (CitadelConfigManager.shouldLogInternal()) {
+				Citadel.getInstance().getLogger().log(Level.INFO, "Adding Reinforcement {0} with:\n  material {1} \n  amount {2} " +
+						"\n  return rate {3} \n  return? {4} \n  health {5} \n  maturation {6} " +
+						"\n  acid {7} \n  scaling {8} \n  lore: {9}", new Object[] {
+						type, mat.toString(), amount, percentReturn, returnValue, hitpoints,
+						maturation, acid, maturation_scale, (lore != null ? String.join("   ", lore) : "")});
+			}
 		}
     }
 	/**


### PR DESCRIPTION
Finishing up some basic listeners for player interactions with reinforcements

Cleaned up logging and added more, continuing to work through and clean up codebaes

Cleanup continued with only listeners left and cleanup testing of cleanup.

Adding proper player command _response_ logging, fixes. I think this is largely it for Citadel improvements for now.

Adding command to allow live updating of internal logging.

Fixes based on Zion livetest, works, adjusted logging levels appropriate and have sensible defaults.